### PR TITLE
 [IMP] set_defaults: Don't use ORM by default.

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -432,7 +432,7 @@ def warn_possible_dataloss(cr, pool, old_module, fields):
                     field['field'], field['new_module'], row[0])
 
 
-def set_defaults(cr, pool, default_spec, force=False):
+def set_defaults(cr, pool, default_spec, force=False, use_orm=False):
     """
     Set default value. Useful for fields that are newly required. Uses orm, so
     call from the post script.
@@ -447,15 +447,18 @@ def set_defaults(cr, pool, default_spec, force=False):
     process. Beware of issues with resources loaded from new data that \
     actually do require the model's default, in combination with the post \
     script possible being run multiple times.
+    :param use_orm: If set to True, the write operation of the default value \
+    will be triggered using ORM instead on an SQL clause (default).
     """
 
     def write_value(ids, field, value):
         logger.debug(
             "model %s, field %s: setting default value of resources %s to %s",
             model, field, ids, unicode(value))
-        for res_id in ids:
-            # Iterating over ids here as a workaround for lp:1131653
-            obj.write(cr, SUPERUSER_ID, [res_id], {field: value})
+        if use_orm:
+            for res_id in ids:
+                # Iterating over ids here as a workaround for lp:1131653
+                obj.write(cr, SUPERUSER_ID, [res_id], {field: value})
 
     for model in default_spec.keys():
         obj = pool.get(model)
@@ -463,6 +466,13 @@ def set_defaults(cr, pool, default_spec, force=False):
             raise orm.except_orm(
                 "Error",
                 "Migration: error setting default, no such model: %s" % model)
+        else:
+            cr.execute(
+                """
+                UPDATE %s
+                SET %s = %%s
+                WHERE id IN %%s
+                """ % (obj._table, field), (value, tuple(ids)))
 
         for field, value in default_spec[model]:
             domain = not force and [(field, '=', False)] or []


### PR DESCRIPTION
For now, I'm not bumping version nor writing history until #3 is solved.

This improvement is already approved and merged on 7.0 branch of OpenUpgrade in https://github.com/OCA/OpenUpgrade/pull/340