### PR TITLE
[IMP] update_module_names: Handle ir_translation

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -564,6 +564,10 @@ def update_module_names(cr, namespec):
         query = ("UPDATE ir_module_module_dependency SET name = %s "
                  "WHERE name = %s")
         logged_query(cr, query, (new_name, old_name))
+        if release.version_info[0] > 7:
+            query = ("UPDATE ir_translation SET module = %s "
+                     "WHERE module = %s")
+            logged_query(cr, query, (new_name, old_name))
 
 
 def add_ir_model_fields(cr, columnspec):


### PR DESCRIPTION
Although not a blocking point, as translations are re-loaded on module update, it's good for avoiding garbage records and preserve possible custom labels.