### PR TITLE
[IMP] make apidocs available on rtfd.org

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = "sphinx-apidoc -f -o docs ../openupgradelib && sphinx-build"
 PAPER         =
 BUILDDIR      = _build
 


### PR DESCRIPTION
Try to solve the problem, that on ReadTheDocs, still there is no autoupdated docstring apidocumentation available.

Something very useful.