### PR TITLE
Avoid broken updates

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -945,7 +945,8 @@ def migrate(no_version=False):
                 (module, stage, version))
             try:
                 # The actual function is called here
-                func(cr, version)
+                with cr.savepoint():
+                    func(cr, version)
             except Exception as e:
                 logger.error(
                     "%s: error in migration script %s: %s" %


### PR DESCRIPTION
If a migration fails, it will get reverted.