### PR TITLE
[FIX] docstring warnings

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -223,10 +223,10 @@ def copy_columns(cr, column_spec):
     """
     Copy table columns. Typically called in the pre script.
 
-    :param column_spec: a hash with table keys, with lists of tuples as \
-    values. Tuples consist of (old_name, new_name, type). Use None for \
-    new_name to trigger a conversion of old_name using get_legacy_name() \
-    Use None for type to use type of old field.
+    :param column_spec: a hash with table keys, with lists of tuples as
+        values. Tuples consist of (old_name, new_name, type). Use None for
+        new_name to trigger a conversion of old_name using get_legacy_name()
+        Use None for type to use type of old field.
         Make sure to quote properly, if your column name coincides with a
         SQL directive. eg. '"column"'
 

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -227,8 +227,8 @@ def copy_columns(cr, column_spec):
     values. Tuples consist of (old_name, new_name, type). Use None for \
     new_name to trigger a conversion of old_name using get_legacy_name() \
     Use None for type to use type of old field.
-    Make sure to quote properly, if your column name coincides with a
-    SQL directive. eg. '"column"'
+        Make sure to quote properly, if your column name coincides with a
+        SQL directive. eg. '"column"'
 
     .. versionadded:: 8.0
     """
@@ -795,7 +795,7 @@ def float_to_integer(cr, table, field):
         "TYPE integer" % {
             'table': table,
             'field': field,
-            })
+        })
 
 
 def map_values(
@@ -811,8 +811,8 @@ def map_values(
     mapped
     :param target_column: the database column, or model field (if 'write' is \
     'orm') that the new values are written to
-    :para mapping: list of tuples [(old value, new value)]
-    Old value True represents "is set", False "is not set".
+    :param mapping: list of tuples [(old value, new value)]
+        Old value True represents "is set", False "is not set".
     :param model: used for writing if 'write' is 'orm', or to retrieve the \
     table if 'table' is not given.
     :param table: the database table used to query the old values, and write \


### PR DESCRIPTION
this fixes warnings when building the openupgrade documentation:
```
/var/tmp/openupgrade/openupgradelib/openupgradelib/openupgrade.py:docstring of openupgradelib.openupgrade.copy_columns:4: WARNING: Field list ends without a blank line; unexpected unindent.
/var/tmp/openupgrade/openupgradelib/openupgradelib/openupgrade.py:docstring of openupgradelib.openupgrade.map_values:9: WARNING: Field list ends without a blank line; unexpected unindent.
```