### PR TITLE
[IMP] Add xml mapping functionality

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -874,11 +874,11 @@ def map_values(
         }
         query = ("SELECT {source_column!s} FROM {table!s}").format(**values)
         cr.execute(query)
-        
+
         set1 = set([i[0] for i in cr.fetchall()])
         set2 = set([i[0] for i in mapping])
         missing = set1 - set2
-        
+
         if (missing - set([None])):
             for dbid in missing:
                 logger.error((

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -874,9 +874,11 @@ def map_values(
         }
         query = ("SELECT {source_column!s} FROM {table!s}").format(**values)
         cr.execute(query)
-
-        missing = set([i[0] for i in cr.fetchall()]) - \
-        set([i[0] for i in mapping])
+        
+        set1 = set([i[0] for i in cr.fetchall()])
+        set2 = set([i[0] for i in mapping])
+        missing = set1 - set2
+        
         if (missing - set([None])):
             for dbid in missing:
                 logger.error((

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -880,13 +880,12 @@ def map_values(
         missing = set1 - set2
 
         if (missing - set([None])):
-            for dbid in missing:
-                logger.error((
-                    "'map_values_by_xml' has detected a missing mapping for "
-                    "Database ID {0} in Source Column (check_completness "
-                    "enabled)."
-                ).format(dbid))
-            raise
+            logger.excpetion((
+                "'map_values' has detected missing mappings for "
+                "following values in Source Column (check_completness "
+                "enabled):\n{0}"
+            ).format(('\n').join(missing))
+
     for old, new in mapping:
         new = "'%s'" % new
 

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -876,7 +876,7 @@ def map_values(
         cr.execute(query)
 
         missing = set([i[0] for i in cr.fetchall()]) - \
-                  set([i[0] for i in mapping])
+        set([i[0] for i in mapping])
         if (missing - set([None])):
             for dbid in missing:
                 logger.error((

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -799,8 +799,8 @@ def float_to_integer(cr, table, field):
 
 
 def map_values(
-        cr, source_column, target_column, mapping, xml_mapping=False,
-        model=None, table=None, write='sql', check_completeness=False):
+        cr, source_column, target_column, mapping, model=None,
+        table=None, write='sql', xml_mapping=False, check_completeness=False):
     """
     Map old values to new values within the same model or table. Old values
     presumably come from a legacy column.

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -822,11 +822,6 @@ def map_values(
     identified by an sql read.
     :param check_completeness: True verifies, that all source entries \
     have been accounted for in the mapping table and raises otherwise.
-
-    This moethod does not support mapping values across tables, neither \
-    relational nor property fields (it does not support resiliant \
-    handling of their respective relational tables - you still can use \
-    this method on those relational tables in sql mode).
     .. versionadded:: 8.0
     """
     def use_xml_mapping(cr, mapping):

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -852,7 +852,7 @@ def map_values(
         return result
 
     if xml_mapping:
-        mapping = use_xml_mapping(cr, xml_mapping)
+        mapping = use_xml_mapping(cr, mapping)
 
     if write not in ('sql', 'orm'):
         logger.exception(


### PR DESCRIPTION
- maps a fully qualified xml dict to it's database ids
- migrates the values via map_value
- includes an optional cke to verify if all source column values have a mapping
- otherwise ignores faulty tuples of the mapping resolution
- but has a magical external id named 'NULL' which matches a database NULL in source and destination column
- as per map_value behaviour: does not verify if there are multiple conflicting mappings (one old with several new)

Please give feedback. Especially, I need to know how, where to include the imports and the imd in order to make it openupgradelib-ish. Also feedback in terms of functionality (completeness and scope) would be nice.

I think the use case is rather obvious, just ping me for any doubts.