### PR TITLE
[IMP] Add dropping m2m tables

### DIFF
--- a/openupgradelib/cleanup.py
+++ b/openupgradelib/cleanup.py
@@ -28,7 +28,7 @@ logger.setLevel(logging.DEBUG)
 
 ###########################################
 #
-# NOTE: Please try to homologate this library with
+# NOTE: Please try to syntesize this library with
 # database_cleanup module as you contribute
 # You can find it here:
 # https://github.com/OCA/server-tools/tree/9.0/database_cleanup
@@ -54,7 +54,7 @@ def drop_m2m_table(env, table_spec):
     :param cr: The database cursor
     :param table_spec: list of strings ['table one', 'table two']
 
-    .. versionadded:: 9.0
+    Note: You can use this method from version 8.0 onwards.
     """
     drop = env['ir.model.relation']._module_data_uninstall
     for table in table_spec:
@@ -63,6 +63,9 @@ def drop_m2m_table(env, table_spec):
         env.cr.execute(query)
         ids = [x[0] for x in env.cr.fetchall()]
         drop(ids)
+        query = """DELETE FROM ir_model_relation
+                   WHERE name='{0}'""".format(table)
+        env.cr.execute(query)
 
 
 def drop_columns(cr, column_spec):

--- a/openupgradelib/cleanup.py
+++ b/openupgradelib/cleanup.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    OpenERP, Open Source Management Solution
+#    This module copyright (C) 2011-2013 Therp BV (<http://therp.nl>)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+import logging
+# from .openupgrade import version_info
+
+logger = logging.getLogger('OpenUpgradeCleanup')
+logger.setLevel(logging.DEBUG)
+
+###########################################
+#
+# NOTE: Please try to homologate this library with
+# database_cleanup module as you contribute
+# You can find it here:
+# https://github.com/OCA/server-tools/tree/9.0/database_cleanup
+#
+# Feel yourself encouraged to contact the author of a
+# similar method in databse_cleanup (git blame).
+#
+###########################################
+
+
+__all__ = [
+    'drop_m2m_table',
+    'drop_columns',
+]
+
+
+def drop_m2m_table(env, table_spec):
+    """
+    Drop a many2many relation table properly.
+    You will typically want to use it in post-migration scripts after you \
+    have migrated the values of your many2many fields.
+
+    :param cr: The database cursor
+    :param table_spec: list of strings ['table one', 'table two']
+
+    .. versionadded:: 9.0
+    """
+    drop = env['ir.model.relation']._module_data_uninstall
+    for table in table_spec:
+        query = """SELECT id FROM ir_model_relation
+                   WHERE name='{0}'""".format(table)
+        env.cr.execute(query)
+        ids = [x[0] for x in env.cr.fetchall()]
+        drop(ids)
+
+
+def drop_columns(cr, column_spec):
+    """
+    Drop columns but perform an additional check if a column exists.
+    This covers the case of function fields that may or may not be stored.
+    Consider that this may not be obvious: an additional module can govern
+    a function fields' store properties.
+
+    :param column_spec: a list of (table, column) tuples
+    """
+    for (table, column) in column_spec:
+        logger.info("table %s: drop column %s",
+                    table, column)
+        if column_exists(cr, table, column):
+            cr.execute('ALTER TABLE "%s" DROP COLUMN "%s"' %
+                       (table, column))
+        else:
+            logger.warn("table %s: column %s did not exist",
+                        table, column)

--- a/openupgradelib/cleanup.py
+++ b/openupgradelib/cleanup.py
@@ -20,6 +20,7 @@
 ##############################################################################
 
 import logging
+from .openupgrade import column_exists
 # from .openupgrade import version_info
 
 logger = logging.getLogger('OpenUpgradeCleanup')

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -379,44 +379,15 @@ def add_xmlid(cr, module, xmlid, model, res_id, noupdate=False):
 
 
 def drop_columns(cr, column_spec):
-    """
-    Drop columns but perform an additional check if a column exists.
-    This covers the case of function fields that may or may not be stored.
-    Consider that this may not be obvious: an additional module can govern
-    a function fields' store properties.
-
-    :param column_spec: a list of (table, column) tuples
-    """
-    for (table, column) in column_spec:
-        logger.info("table %s: drop column %s",
-                    table, column)
-        if column_exists(cr, table, column):
-            cr.execute('ALTER TABLE "%s" DROP COLUMN "%s"' %
-                       (table, column))
-        else:
-            logger.warn("table %s: column %s did not exist",
-                        table, column)
-
-
-def drop_m2m_table(cr, table_spec):
-    """
-    Drop a many2many relation table properly.
-    You will typically want to use it in post-migration scripts after you \
-    have migrated the values of your many2many fields.
-
-    :param cr: The database cursor
-    :param table_spec: list of strings ['table one', 'table two']
-
-    .. versionadded:: 9.0
-    """
-    imr = RegistryManager.get(cr.dbname)['ir.model.relation']
-    drop = imr._module_data_uninstall
-    for table in table_spec:
-        query = """SELECT id FROM ir_model_relation
-                   WHERE name='{0}'""".format(table)
-        cr.execute(query)
-        ids = [x[0] for x in cr.fetchall()]
-        drop(cr, SUPERUSER_ID, ids)
+    logger.warning(
+        'drop_columns has been moved to openupgradelib.cleanup'
+        'opneupgradlib.cleanup is a place to gather cleanup methods.'
+        'Please consider adapting your migration scripts.'
+        'Utilizing cleanup methods is not encouraged, consider using '
+        'the module database_cleanup instead.'
+    )
+    from .cleanup import drop_columns as _dc
+    _dc(cr=cr, column_sepc=column_spec)
 
 
 def update_workflow_workitems(cr, pool, ref_spec_actions):

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -403,10 +403,10 @@ def drop_m2m_table(cr, table_spec):
     Drop a many2many relation table properly.
     You will typically want to use it in post-migration scripts after you \
     have migrated the values of your many2many fields.
-    
+
     :param cr: The database cursor
     :param table_spec: list of strings ['table one', 'table two']
-    
+
     .. versionadded:: 9.0
     """
     imr = RegistryManager.get(cr.dbname)['ir.model.relation']

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -398,6 +398,27 @@ def drop_columns(cr, column_spec):
                         table, column)
 
 
+def drop_m2m_table(cr, table_spec):
+    """
+    Drop a many2many relation table properly.
+    You will typically want to use it in post-migration scripts after you \
+    have migrated the values of your many2many fields.
+    
+    :param cr: The database cursor
+    :param table_spec: list of strings ['table one', 'table two']
+    
+    .. versionadded:: 9.0
+    """
+    imr = RegistryManager.get(cr.dbname)['ir.model.relation']
+    drop = imr._module_data_uninstall
+    for table in table_spec:
+        query = """SELECT id FROM ir_model_relation
+                   WHERE name='{0}'""".fromat(table)
+        cr.execute(query)
+        ids = [x[0] for x in cr.fetchall()]
+        drop(cr, SUPERUSER_ID, ids)
+
+
 def update_workflow_workitems(cr, pool, ref_spec_actions):
     """Find all the workflow items from the target state to set them to
     the wanted state.

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -413,7 +413,7 @@ def drop_m2m_table(cr, table_spec):
     drop = imr._module_data_uninstall
     for table in table_spec:
         query = """SELECT id FROM ir_model_relation
-                   WHERE name='{0}'""".fromat(table)
+                   WHERE name='{0}'""".format(table)
         cr.execute(query)
         ids = [x[0] for x in cr.fetchall()]
         drop(cr, SUPERUSER_ID, ids)

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -24,6 +24,7 @@ import os
 import inspect
 import uuid
 import logging
+import warnings
 from contextlib import contextmanager
 from . import openupgrade_tools
 try:
@@ -379,12 +380,12 @@ def add_xmlid(cr, module, xmlid, model, res_id, noupdate=False):
 
 
 def drop_columns(cr, column_spec):
-    logger.warning(
+    warnings.warn(
         'drop_columns has been moved to openupgradelib.cleanup'
         'opneupgradlib.cleanup is a place to gather cleanup methods.'
         'Please consider adapting your migration scripts.'
         'Utilizing cleanup methods is not encouraged, consider using '
-        'the module database_cleanup instead.'
+        'the module database_cleanup instead.', DeprecationWarning
     )
     from .cleanup import drop_columns as _dc
     _dc(cr=cr, column_sepc=column_spec)


### PR DESCRIPTION
- Drops many2many tables after migration through the ORM

Use case:
Dropping a many2many field in a migration is not automatically cleaned by the ORM (only deleting the whole module does that). So if you removed a m2m field in a model through migration you want to clean up after you thanks to this small wrapper.

Thanks in advance for your time, feedback, collaboration and eventual merging.
