### PR TITLE
[IMP] Add Environment manager for version >=8

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -962,18 +962,18 @@ def reactivate_workflow_transitions(cr, transition_conditions):
             (condition, transition_id))
 
 
-def migrate(no_version=False, v8api=False, context=None, *args, **kwargs):
+def migrate(no_version=False, v9env=False, context=None, *args, **kwargs):
     """
     This is the decorator for the migrate() function in migration scripts.
     It returns if `version` is not defined and `no_version` is False,
     and logs execeptions. It also retrieves debug context data from the
     frame above for logging purposes. Optionally it provides a fully fledged
-    Odoo Environment (with `v8api` = True). An arbitrary context can be
+    Odoo Environment (with `v9env` = True). An arbitrary context can be
     preloaded into the Environment via `context` dict.
 
     :param no_version: Set to `True` if the migrate method has to be taken
     into account if the module is installed during a migration.
-    :param v8api: Set to `True` gives you a fully fledged Odoo Environment.
+    :param v9env: Set to `True` gives you a fully fledged Odoo Environment.
     The wrapped function signature changes to `migrate(env, *args, **kwargs):`
         Obtain Version: env.context['migrate_version']
         Obtain Cursor: env.cr

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1009,12 +1009,12 @@ def migrate(no_version=False, v8api=False, context=None, *args, **kwargs):
                 "%s: %s-migration script called with version %s" %
                 (module, stage, version))
             versioncheck = (version_info[0] >= 8 and v9env) or version_info > 9
-            if not versioncheck and not v9env:
+            if not versioncheck:
                 logger.warning(
                     "You are are using the decorator without the Environment "
                     "creation feature. As of Odoo Version 10 Migrations, the "
                     "Environment will be enabled by default. Make sure to "
-                    "gat aquiainted with the slightly different migrate() "
+                    "get acquainted with the slightly different migrate() "
                     "signature in time: `def migrate(env, *args, **kwargs)`"
                 )
             try:

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1008,7 +1008,6 @@ def migrate(no_version=False, v8api=False, context=None, *args, **kwargs):
             logger.info(
                 "%s: %s-migration script called with version %s" %
                 (module, stage, version))
-            def call_funct
             versioncheck = (version_info[0] >= 8 and v9env) or version_info > 9
             if not versioncheck and not v9env:
                 logger.warning(

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -962,7 +962,7 @@ def reactivate_workflow_transitions(cr, transition_conditions):
             (condition, transition_id))
 
 
-def migrate(no_version=False, v9env=False, context=None, *args, **kwargs):
+def migrate(no_version=False, v9env=None, context=None, *args, **kwargs):
     """
     This is the decorator for the migrate() function in migration scripts.
     It returns if `version` is not defined and `no_version` is False,
@@ -974,6 +974,7 @@ def migrate(no_version=False, v9env=False, context=None, *args, **kwargs):
     :param no_version: Set to `True` if the migrate method has to be taken
     into account if the module is installed during a migration.
     :param v9env: Set to `True` gives you a fully fledged Odoo Environment.
+    As per v10, you automatically get it, but can disable with `False`.
     The wrapped function signature changes to `migrate(env, *args, **kwargs):`
         Obtain Version: env.context['migrate_version']
         Obtain Cursor: env.cr
@@ -1008,7 +1009,9 @@ def migrate(no_version=False, v9env=False, context=None, *args, **kwargs):
             logger.info(
                 "%s: %s-migration script called with version %s" %
                 (module, stage, version))
-            versioncheck = (version_info[0] >= 8 and v9env) or version_info > 9
+            versioncheck = (version_info[0] >= 8 and v9env) or (
+                version_info > 9 and not v9env == False
+            )
             if not versioncheck:
                 logger.warning(
                     "You are are using the decorator without the Environment "

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -25,7 +25,7 @@ import inspect
 import uuid
 import logging
 from contextlib import contextmanager
-from functools import wrap # for better debuggin support
+from functools import wraps  # for better debuggin support
 from . import openupgrade_tools
 try:
     from openerp import release
@@ -1002,8 +1002,10 @@ def migrate(no_version=False, context=None, *args, **kwargs):
                         if version_info[0] >= 8:
                             with api.Environment.manage():
                                 context['migrate_version'] = version
-                                Env = api.Environment(cr, SUPERUSER_ID, context)
-                                return func(Env, *args, **kwargs)
+                                env = api.Environment(
+                                    cr, SUPERUSER_ID, context
+                                )
+                                return func(env, *args, **kwargs)
                         else:
                             return func(cr, version)
                 else:
@@ -1013,13 +1015,15 @@ def migrate(no_version=False, context=None, *args, **kwargs):
                         if version_info[0] >= 8:
                             with api.Environment.manage():
                                 context['migrate_version'] = version
-                                Env = api.Environment(cr, SUPERUSER_ID, context)
-                                func(Env, *args, **kwargs)
+                                env = api.Environment(
+                                    cr, SUPERUSER_ID, context
+                                )
+                                func(env, *args, **kwargs)
                                 cr.execute('RELEASE SAVEPOINT "%s"' % name)
                         else:
                             func(cr, version)
                             cr.execute('RELEASE SAVEPOINT "%s"' % name)
-                            
+
                     except:
                         cr.execute('ROLLBACK TO SAVEPOINT "%s"' % name)
                         raise

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1010,7 +1010,7 @@ def migrate(no_version=False, v9env=None, context=None, *args, **kwargs):
                 "%s: %s-migration script called with version %s" %
                 (module, stage, version))
             versioncheck = (version_info[0] >= 8 and v9env) or (
-                version_info > 9 and not v9env == False
+                version_info > 9 and v9env is not False
             )
             if not versioncheck:
                 logger.warning(


### PR DESCRIPTION
- Includes an environment manager in the @migrate() decorator as of odoo version 8
- Makes it possible to access to the well known new-style `self.env` via `Env`

For instance, the statements:

```
model = self.pool.get(MODEL)
ids = model.search(cr, uid, DOMAIN, context=context)
for rec in model.browse(cr, uid, ids, context=context):
    print rec.name
model.write(cr, uid, ids, VALUES, context=context)
```
may also be written as:
```
model = Env[MODEL]                  # retrieve an instance of MODEL
recs = model.search(DOMAIN)         # search returns a recordset
for rec in recs:                    # iterate over the records
    print rec.name
recs.write(VALUES)  
```

@Yajo Is that mas o menos right, what I did with your idea?

Note the context argument on the migrate decorator for whatever it might be good in the future...

Migrations scripts would need to pass `Env.cr` on behalf of `cr`, but we could easily include the `cr` for legacy reasons.

Of course, once this is codewise mergeable, we need to proceed to proper documentation.

Thanks for your time, collaboration, effort, review and good vibes!