### PR TITLE
[IMP] prep get_legacy_name for orm copy and include module version

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -692,8 +692,8 @@ def get_legacy_name(original_name):
     :param original_name: the original name of the column
     :param version: current version as passed to migrate()
     """
-    return 'openupgrade_legacy_' + '_'.join(
-        map(str, version_info[0:2])) + '_' + original_name
+    return 'x_ou_legacy_' + '_'.join(
+        map(str, version_info[0:])) + '_' + original_name
 
 
 def m2o_to_x2m(cr, model, table, field, source_field):


### PR DESCRIPTION
- prefixes columns with "x_", the orm standard for manual fields. 
This enables a "pre-post migration persistent" field copy function through the ORM, which in turn enables m2m copying.
- Include module version, as openupgradelib is increasingly used in individual module migration.