### PR TITLE
[IMP] clarifying docstring

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -820,6 +820,9 @@ def map_values(
     :param write: Either 'orm' or 'sql'. Note that old ids are always \
     identified by an sql read.
 
+    This moethod does not support mapping m2m, o2m or property fields. \
+    For o2m you can migrate the inverse field's column instead.
+
     .. versionadded:: 8.0
     """
 


### PR DESCRIPTION
- Clarify that some fields are not supported. 
(it is implicit in columns != fields, but explicitly is more friendly)

I wasn't 100% sure about property fields, but as they are stored in a separate table, I assumed that it's the case like for m2m.