### PR TITLE
[IMP] make legacy names orm aware

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -690,9 +690,8 @@ def get_legacy_name(original_name):
     collisions with future or past legacy tables/columns/etc
 
     :param original_name: the original name of the column
-    :param version: current version as passed to migrate()
     """
-    return 'openupgrade_legacy_' + '_'.join(
+    return 'x_ou_' + '_'.join(
         map(str, version_info[0:2])) + '_' + original_name
 
 


### PR DESCRIPTION
- preserves version logic
- reduces legacy prefix (just to save on characters)
- includes odoo's magical `x_` prefix

Rationale:

By prefixing with `x_`, ORM understands `manual` fields, where applicable.

This behaviour enables the creation of backup columns through the ORM in pre migrations scripts, while being able to access this information in post migration.

Without this behaviour, during the actual module upgrade, the ORM would sync DB and Registry with the module's model definition. Any "ORM aware" columns/fields created in pre migration would be wiped away.

A typical use case is the copying of a m2m field together with its values, while being able to access it with the convenience of (metonymy:) recordsets and `mapped()` functions in post migration (what is referred to before as "ORM aware" fields). Pending #45 relies on this behaviour.
