### PR TITLE
Update module field in ir_model_fields when calling rename_models.

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -322,6 +322,8 @@ def rename_models(cr, model_spec):
                    'WHERE model = %s', (new, old,))
         cr.execute('UPDATE ir_attachment SET res_model = %s '
                    'WHERE res_model = %s', (new, old,))
+        cr.execute('UPDATE ir_model_fields SET model = %s '
+                   'WHERE model = %s', (new, old,))
     # TODO: signal where the model occurs in references to ir_model
 
 


### PR DESCRIPTION
rename_models() does not change 'module' field in ir_model_fields.
This PR adds 'module' query to properly rename model fields.
A separate query is used from the one that updates 'relation' field as it's not always the same.