### PR TITLE
[FIXIMP] fix docstring, bug and imp [Merge Ready]

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1013,15 +1013,15 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
     Set argument `no_version` to True if the method as to be taken into account
     if the module is installed during a migration.
 
-    Set argument `pass_env` if you want an v8+ environment instead of a plain
+    Set argument `use_env` if you want an v8+ environment instead of a plain
     cursor. Starting from version 10, this is the default
 
     The arguments `uid` and `context` can be set when an evironment is
     requested. In the cursor case, they're ignored.
 
     The migration function's signature must be `func(cr, version)` if
-    `pass_env` is `False` or not set and the version is below 10, or
-    `func(env, version)` if `pass_env` is `True` or not set and the version is
+    `use_env` is `False` or not set and the version is below 10, or
+    `func(env, version)` if `use_env` is `True` or not set and the version is
     10 or higher.
 
     Return when the `version` argument is not defined and `no_version` is False
@@ -1037,7 +1037,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
             filename = 'unknown'
             with ExitStack() as contextmanagers:
                 contextmanagers.enter_context(savepoint(cr))
-                use_env2 = use_env is None and version_info[0] > 10 or use_env
+                use_env2 = use_env is None and version_info[0] >= 10 or use_env
                 if use_env2:
                     assert version_info[0] >= 8, 'you need at least v8'
                     contextmanagers.enter_context(api.Environment.manage())
@@ -1056,6 +1056,9 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                 logger.info(
                     "%s: %s-migration script called with version %s" %
                     (module, stage, version))
+                # Set up useful default context values
+                context['migrate_version'] = version and version or None
+                context['module_name'] = module and module or None
                 try:
                     # The actual function is called here
                     func(

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1035,6 +1035,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
             stage = 'unknown'
             module = 'unknown'
             filename = 'unknown'
+            
             with ExitStack() as contextmanagers:
                 contextmanagers.enter_context(savepoint(cr))
                 use_env2 = use_env is None and version_info[0] >= 10 or use_env
@@ -1057,6 +1058,8 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                     "%s: %s-migration script called with version %s" %
                     (module, stage, version))
                 # Set up useful default context values
+                if not context:
+                    context = {}
                 context['migrate_version'] = version and version or None
                 context['module_name'] = module and module or None
                 try:
@@ -1064,7 +1067,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                     func(
                         use_env2 and
                         api.Environment(
-                            cr, uid or SUPERUSER_ID, context or {}) or
+                            cr, uid or SUPERUSER_ID, context) or
                         cr,
                         version)
                 except Exception as e:

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -25,6 +25,7 @@ import inspect
 import uuid
 import logging
 from contextlib import contextmanager
+from functools import wraps
 try:
     from contextlib import ExitStack
 except ImportError:
@@ -1031,7 +1032,9 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
     logging purposes.
     """
     def wrap(func):
-        def wrapped_function(cr, version):
+        @wraps(func)
+        def wrapped_function(cr, version, no_version=no_version, use_env=use_env,
+                             uid=uid, context=context):
             stage = 'unknown'
             module = 'unknown'
             filename = 'unknown'

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1033,8 +1033,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
     """
     def wrap(func):
         @wraps(func)
-        def wrapped_function(cr, version, no_version=no_version, use_env=use_env,
-                             uid=uid, context=context):
+        def wrapped_function(cr, version):
             stage = 'unknown'
             module = 'unknown'
             filename = 'unknown'
@@ -1061,15 +1060,15 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                     "%s: %s-migration script called with version %s" %
                     (module, stage, version))
                 # Set up useful default context values
-                context = context or {}
-                context['migrate_version'] = version and version or None
-                context['module_name'] = module and module or None
+                context2 = context or {}
+                context2['migrate_version'] = version and version or None
+                context2['module_name'] = module and module or None
                 try:
                     # The actual function is called here
                     func(
                         use_env2 and
                         api.Environment(
-                            cr, uid or SUPERUSER_ID, context) or
+                            cr, uid or SUPERUSER_ID, context2) or
                         cr,
                         version)
                 except Exception as e:

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1058,8 +1058,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                     "%s: %s-migration script called with version %s" %
                     (module, stage, version))
                 # Set up useful default context values
-                if not context:
-                    context = {}
+                context = context or {}
                 context['migrate_version'] = version and version or None
                 context['module_name'] = module and module or None
                 try:

--- a/tests/test_openupgradelib.py
+++ b/tests/test_openupgradelib.py
@@ -56,7 +56,7 @@ class TestOpenupgradelib(unittest.TestCase):
         def migrate_with_cr(cr, version):
             self.assertTrue(isinstance(cr, mock.Mock))
 
-        @openupgrade.migrate(use_env=True, context=None)
+        @openupgrade.migrate(use_env=True)
         def migrate_with_env(env, version):
             self.assertTrue(isinstance(env.cr, mock.Mock))
 

--- a/tests/test_openupgradelib.py
+++ b/tests/test_openupgradelib.py
@@ -56,7 +56,7 @@ class TestOpenupgradelib(unittest.TestCase):
         def migrate_with_cr(cr, version):
             self.assertTrue(isinstance(cr, mock.Mock))
 
-        @openupgrade.migrate(use_env=True)
+        @openupgrade.migrate(use_env=True, context=None)
         def migrate_with_env(env, version):
             self.assertTrue(isinstance(env.cr, mock.Mock))
 


### PR DESCRIPTION
- Fix Docstring
- Fix wrong condition
- Set up useful defaults in context
  -- version and module can be used throughout scripts to construct unique hashes of the current precise migration context (eg. for naming schemes)

@hbrunn
