### PR TITLE
[FIX] support versions without _fields

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -804,7 +804,7 @@ def m2o_to_x2m(cr, model, table, field, source_field):
 
     .. versionadded:: 8.0
     """
-    columns = getattr(model, '_columns', getattr(model, '_fields'))
+    columns = getattr(model, '_columns', False) or getattr(model, '_fields')
     if not columns.get(field):
         do_raise("m2o_to_x2m: field %s doesn't exist in model %s" % (
             field, model._name))


### PR DESCRIPTION
mind you that python doesn't have lazy evaluation of function parameters, so also the fallback we pass to `getattr` is evaluated immediately