### PR TITLE
[ADD] support update mode where we never try to create records

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ coveralls
 # Version locked due to https://gitlab.com/pycqa/flake8/issues/268
 flake8==3.2.0
 pep8-naming
+lxml


### PR DESCRIPTION
this is meant to allow loading `noupdate="1"` records and being sure nothing bad happens when doing this.

Currently, if you `load_data` with records that were noupdate, forcecreate=False and deleted, odoo will generate a `create`, which fails if there are any required fields that are not included in the xml

cc @pedrobaeza 