### PR TITLE
Fix logging with non-ascii characters in exception.

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1390,9 +1390,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                             cr, uid or SUPERUSER_ID, context or {})
                         if use_env2 else cr, version)
                 except Exception as e:
-                    message = str(e)
-                    if sys.version_info[0] == 2:
-                        message = message.decode('utf8')
+                    message = repr(e) if sys.version_info[0] == 2 else str(e)
                     logger.error(
                         "%s: error in migration script %s: %s",
                         module, filename, message)


### PR DESCRIPTION
str() should never be used in Python 2 if you can not know the encoding
of the string.

In this case it can log and raise a UnicodeEncodeError in migration.log
instead of the exception causing the error, and you cannot know why
your migration failed.

I use repr() for Python 2. It's not perfect but the exception is
displayed and the stacktrace is in the log because of logger.exception(),
which is bypassed if str() cause another exception.

Resolve #90 