### PR TITLE
[RFC] rename field xmlids when renaming models

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -532,12 +532,28 @@ def rename_models(cr, model_spec):
     for (old, new) in model_spec:
         logger.info("model %s: renaming to %s",
                     old, new)
+        _old = old.replace('.', '_')
+        _new = new.replace('.', '_')
         cr.execute('UPDATE ir_model SET model = %s '
                    'WHERE model = %s', (new, old,))
         cr.execute('UPDATE ir_model_fields SET relation = %s '
                    'WHERE relation = %s', (new, old,))
         cr.execute('UPDATE ir_model_data SET model = %s '
                    'WHERE model = %s', (new, old,))
+        cr.execute(
+            'UPDATE ir_model_data SET name=%s '
+            "WHERE name=%s AND model = 'ir.model'",
+            (
+                'model_' + _new, 'model_' + _old,
+            )
+        )
+        cr.execute(
+            'UPDATE ir_model_data SET name=regexp_replace(name, %s, %s) '
+            "WHERE name like %s AND model = 'ir.model.fields'",
+            (
+                '^field_' + _old, 'field_' + _new, 'field_' + _old + '_%',
+            )
+        )
         cr.execute('UPDATE ir_attachment SET res_model = %s '
                    'WHERE res_model = %s', (new, old,))
         cr.execute('UPDATE ir_model_fields SET model = %s '


### PR DESCRIPTION
so every field has an xmlid of the form `field_$modelname_$fieldname` where in the model name, periods are replaced by underscores. When renaming a model, we have to update this too, because Odoo only created those xmlids when *creating* a column, and our columns already exist: https://github.com/OCA/OCB/blob/8.0/openerp/models.py#L428

Now, the code below works fine for my use case, but imagine renaming a model whose name is a substring of other existing models (we want to rename `res.partner`, but there's also `res.partner.category` for example), then the below blows up. Any ideas? A join over ir_model_fields, ir_model is the only thing I can think of, so any better ideas?