### PR TITLE
Disable filters with invalid context.

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1742,7 +1742,15 @@ def disable_invalid_filters(env):
             f.active = False
             continue
         # CONTEXT GROUP BY
-        context = safe_eval(f.context, {'time': time, 'uid': env.uid})
+        try:
+            context = safe_eval(f.context, {'time': time, 'uid': env.uid})
+        except Exception:
+            logger.warning(
+                format_message(f) + "as it contains an invalid context %s.",
+                f.context
+            )
+            f.active = False
+            continue
         keys = ['group_by', 'col_group_by']
         for key in keys:
             if not context.get(key):


### PR DESCRIPTION
I've found SyntaxError in the context of custom filters:

```
2018-01-15 17:24:42,154 29768 WARNING db1 openupgrade: FILTER DISABLED: Filter 'xxxxx for user 'yyyyy for model 'purchase.requisition' has been disabled as it contains an invalid context {'default_user_id': 5, ['account_analytic_id']}.
```

This commit invalidates them.