### PR TITLE
rename_columns: do not fail if table does not exist

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -381,7 +381,7 @@ def rename_columns(cr, column_spec):
             logger.info("table %s, column %s: renaming to %s",
                         table, old, new)
             cr.execute(
-                'ALTER TABLE "%s" RENAME "%s" TO "%s"' % (table, old, new,))
+                'ALTER TABLE IF EXISTS "%s" RENAME "%s" TO "%s"' % (table, old, new,))
             cr.execute('DROP INDEX IF EXISTS "%s_%s_index"' % (table, old))
 
 


### PR DESCRIPTION
This helps with the migration of payment orders on 8.0 databases with an old version of account_banking_payment_transfer.