### PR TITLE
Performance - SQL version of last_message_post

### DIFF
--- a/openupgradelib/openupgrade_80.py
+++ b/openupgradelib/openupgrade_80.py
@@ -78,16 +78,15 @@ def set_message_last_post(cr, uid, pool, models):
         models = [models]
     for model in models:
         model_pool = pool[model]
-        cr.execute('SELECT id FROM {table}'.format(table=model_pool._table))
-        obj_ids = [row[0] for row in cr.fetchall()]
-        for res_id, value in get_last_post_for_model(
-                cr, uid, obj_ids, model_pool).iteritems():
-            if not value:
-                continue
-            cr.execute(
-                "UPDATE {} SET message_last_post = %s WHERE id = %s".format(
-                    model_pool._table),
-                (datetime.strptime(value, DATETIME_FMT), res_id))
+        cr.execute(
+            "UPDATE {table} "
+            "SET message_last_post=(SELECT max(mm.date) "
+            "FROM mail_message mm "
+            "WHERE mm.model=%s "
+            "AND mm.date IS NOT NULL "
+            "AND mm.res_id={table}.id)".format(table=model_pool._table), (model,)
+        )
+
 
 
 def update_aliases(


### PR DESCRIPTION
More an FYI than a PR.

I was having big delays in large tables running set_last_message_post, in fact I never had it complete even in a couple of hours before I just couldn't be bothered.  

So I rewrote in SQL.  On a table with a couple of million invoices completes in ~7 minutes (that is the whole migration, pre, install and post).  This specific query isn't logged but at a guess takes around 5. 

That said, I am yet to verify its correctness but a cursory check looks very good.