### PR TITLE
[FIX] merge_records: tuples and lists don't sum

### DIFF
--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -276,7 +276,7 @@ def _adjust_merged_values_orm(env, model_name, record_ids, target_record_id,
     """
     model = env[model_name]
     fields = model._fields.values()
-    all_records = model.browse(record_ids + [target_record_id])
+    all_records = model.browse(tuple(record_ids) + (target_record_id, ))
     target_record = model.browse(target_record_id)
     vals = {}
     o2m_changes = 0


### PR DESCRIPTION
`record_ids` before was a `list` and now is a `tuple`.