### PR TITLE
merge_records: translations + exception

### DIFF
--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -455,7 +455,9 @@ def merge_records(env, model_name, record_ids, target_record_id,
     args0 = (env, model_name, record_ids, target_record_id)
     args = args0 + (exclude_columns, )
     args2 = args0 + (field_spec, )
-
+    if target_record_id in record_ids:
+        raise Exception("You can't put the target record in the list or "
+                        "records to be merged.")
     _change_generic(*args, method=method)
     if method == 'orm':
         _change_many2one_refs_orm(*args)

--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -458,6 +458,10 @@ def merge_records(env, model_name, record_ids, target_record_id,
     if target_record_id in record_ids:
         raise Exception("You can't put the target record in the list or "
                         "records to be merged.")
+    # Check which records to be merged exist
+    record_ids = env[model_name].browse(record_ids).exists().ids
+    if not record_ids:
+        return
     _change_generic(*args, method=method)
     if method == 'orm':
         _change_many2one_refs_orm(*args)


### PR DESCRIPTION
3 things:

* **[FIX] Handle better translatable fields**

  When merging records from a model that has translatable fields, before this patch, the translations for all the records are reassigned to the target record, provoking duplicated translations. This is even forgiven in v12.

  With this new approach, target translation has priority, and if not present, then the first found is assigned instead.

* **[IMP] merge_records: Put exception condition on records to be merged**

  For avoiding that the target record is also included in records to be merged.

* **[IMP] Check which records to be merged exist**

  This way, if you pass unexisting records to the method, it won't crash.

  In addition, if no records to be merged after this purge, then just return w/o error.

Fixes #13 

@Tecnativa