### PR TITLE
[FIX] SQL request into moved_fields function

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1958,6 +1958,7 @@ def update_module_moved_fields(cr, model, moved_fields, old_module, new_module):
             imf.model = %(model)s AND
             imf.name IN %(fields)s AND
             imd.module = %(old_module)s AND
+            imd.model = 'ir.model.fields' AND
             imd.res_id = imf.id AND
             imd.id NOT IN (
                SELECT id FROM ir_model_data WHERE module = %(new_module)s


### PR DESCRIPTION
Into `update_module_moved_fields` function, the SQL request to update `ir.model.data` for moved fields is incorrect.
We want to update metadata only for model `ir.model.fields`.
Without that, all metadata for `module` with `res_id` returned from `ir.model.fields` are updated.

_Example on my project, for model `res.partner` and field `fax`, we want to move the definition from module `base` to module `xxxxx_partner`:_
```
SELECT imf.model, imd.model, imf.name, imd.name, field_description
        FROM ir_model_fields imf, ir_model_data imd
        WHERE
            imf.model = 'res.partner' AND
            imf.name IN ('fax') AND
            imd.module = 'base' AND
            imd.res_id = imf.id AND
            imd.id NOT IN (
               SELECT id FROM ir_model_data WHERE module = 'xxxxx_partner'
            );
```
_The request without my fix returns too many metadata:_
```
    model    |       model       | name |         name          | field_description 
-------------+-------------------+------+-----------------------+-------------------
 res.partner | ir.model.fields   | fax  | field_res_partner_fax | Fax
 res.partner | ir.module.module  | fax  | module_theme_monglia  | Fax
 res.partner | res.country.state | fax  | state_es_so           | Fax
```
_With my fix, the request just returns metadata for `ir.model.fields`:_
```
    model    |       model       | name |         name          | field_description 
-------------+-------------------+------+-----------------------+-------------------
 res.partner | ir.model.fields   | fax  | field_res_partner_fax | Fax
```