### PR TITLE
[FIX] openupgradelib: TyperError when trying to join and use min() function in bool with strings values

### DIFF
--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -328,6 +328,7 @@ def _adjust_merged_values_orm(env, model_name, record_ids, target_record_id,
             if not op:
                 op = 'other' if field.type == 'char' else 'merge'
             if op == 'merge':
+                l = filter(lambda x: x is not False, l)
                 vals[field.name] = ' | '.join(l)
         elif field.type in ('integer', 'float', 'monetary'):
             if not op:
@@ -347,6 +348,8 @@ def _adjust_merged_values_orm(env, model_name, record_ids, target_record_id,
             elif op == 'or':
                 vals[field.name] = functools.reduce(lambda x, y: x | y, l)
         elif field.type in ('date', 'datetime'):
+            if op:
+                l = filter(lambda x: x is not False, l)
             op = op or 'other'
             if op == 'max':
                 vals[field.name] = max(l)
@@ -355,16 +358,18 @@ def _adjust_merged_values_orm(env, model_name, record_ids, target_record_id,
         elif field.type == 'many2many':
             op = op or 'merge'
             if op == 'merge':
+                l = filter(lambda x: x is not False, l)
                 vals[field.name] = [(4, x.id) for x in l]
         elif field.type == 'one2many':
             op = op or 'merge'
             if op == 'merge':
+                l = filter(lambda x: x is not False, l)
                 o2m_changes += 1
                 l.write({field.inverse_name: target_record_id})
         elif field.type in ('binary', 'many2one'):
             op = op or 'merge'
             if op == 'merge':
-                l = [x for x in l if x]
+                l = filter(lambda x: x, l)
                 if not getattr(target_record, field.name) and l and not \
                         vals.get(field.name):
                     vals[field.name] = l[:1]


### PR DESCRIPTION
When try to merge two records of a model that have a text fields: one of records has a content but the other one is empty this error raised:

```python
TypeError: sequence item 0: expected str instance, bool found
```

The line `vals[field.name] = ' | '.join(l)` in openupgradelib._adjust_merged_values_orm() is trying to join something like `['text content', False]` and that generate the TypeError exception. Here is part of the code

```python
        l = all_records.mapped(field.name)
        if field.type in ('char', 'text', 'html'):
            if not op:
                op = 'other' if field.type == 'char' else 'merge'
            if op == 'merge':
                vals[field.name] = ' | '.join(l)
```
[source here](https://github.com/OCA/openupgradelib/blob/master/openupgradelib/openupgrade_merge_records.py#L331)

This can be reproduced by trying to merge two records of Task Stages (project.task.type) model.
There we have the  'description' field which is of type text.

* Stage A with description field empty (do not set) 
* Stage B with description field with actually content 'example text'

We can also reproduce it easily by doing the next test in a python 3.5 environment

```python
>>> l = ['example text', False]
>>> ' | '.join(l)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    ' | '.join(l)
TypeError: sequence item 1: expected str instance, bool found
```

I believe this change also fix the error reported in #138. There the line that throws the error is because we have a list of strings and bool values that can not be manage by the min() python method (NOTE: This errors only raise in python 3.5 version, if we run the same python test in a python 2.7 environment then the min() will throw no error, the result will be `False`.)
 
```python
>>> l = ['example text', False]
>>> min(l)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    min(l)
TypeError: unorderable types: bool() < str()
```


Please consider this PR and let me know if need to add something else to the PR

Best Regards

