### PR TITLE
[FIX] openupgradelib: adapt StringIO to python3

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -24,10 +24,6 @@ import os
 import inspect
 import uuid
 import logging
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 from contextlib import contextmanager
 try:
     from psycopg2 import errorcodes, ProgrammingError, IntegrityError
@@ -81,6 +77,14 @@ if not hasattr(release, 'version_info'):
     version_info = tuple(map(int, release.version.split('.')))
 else:
     version_info = release.version_info
+
+if version_info[0] < 11:
+    try:
+        from StringIO import StringIO
+    except ImportError:
+        from io import StringIO
+else:
+    from io import StringIO
 
 if version_info[0] > 6 or version_info[0:2] == (6, 1):
     tools = core.tools


### PR DESCRIPTION
In Odoo doc, it has:

```rst
Python 3 reorganised, moved or removed a number of modules in the standard
library:

* ``StringIO`` and ``cStringIO`` were removed, you can use ``io.BytesIO`` and
  ``io.StringIO`` to replace them in a cross-version manner (``io.BytesIO``
  for binary data, ``io.StringIO`` for text/unicode data).
* ``urllib``, ``urllib2`` and ``urlparse`` were redistributed across
  ``urllib.parse`` and ``urllib.request``.
```