### PR TITLE
[IMP] Add XML conversion framework and Bootstrap 3 to 4 converter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ addons:
 script:
     - source ~/virtualenv/python2.7/bin/activate
     - pip install -q -r requirements.txt
-    - flake8 ~/build/OCA/openupgradelib
     - export PYTHONPATH=~/build/OCA/openupgradelib:$PYTHONPATH
     - coverage run setup.py test
     - python setup.py install
@@ -59,6 +58,7 @@ script:
     - pip install psycopg2-binary
     - git reset --hard origin/11.0
     - egrep -v "(openupgradelib)|(psycopg2)" requirements.txt | pip install -q -r /dev/stdin
+    - flake8 ~/build/OCA/openupgradelib
     - ./odoo-bin -d testdb -u all --addons-path addons,/home/travis/build/OCA/openupgradelib/tests/addons --stop-after-init
     # Build docs
     - pip install -q sphinx; sh ~/openupgrade/scripts/build_openupgrade_docs

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -61,10 +61,10 @@ core = None
 # The order matters here. We can import odoo in 9.0, but then we get odoo.py
 try:  # < 10.0
     import openerp as core
-    from openerp.modules import registry as RegistryManager
+    from openerp.modules import registry
 except ImportError:  # >= 10.0
     import odoo as core
-    from odoo.modules import registry as RegistryManager
+    from odoo.modules import registry
 if hasattr(core, 'release'):
     release = core.release
 else:
@@ -1318,7 +1318,7 @@ def deactivate_workflow_transitions(cr, model, transitions=None):
     """
     transition_ids = []
     if transitions:
-        data_obj = RegistryManager.get(cr.dbname)['ir.model.data']
+        data_obj = registry.get(cr.dbname)['ir.model.data']
         for module, name in transitions:
             try:
                 transition_ids.append(
@@ -1751,7 +1751,7 @@ def savepoint(cr):
         try:
             yield
             cr.execute('RELEASE SAVEPOINT "%s"' % name)
-        except:
+        except Exception:
             cr.execute('ROLLBACK TO SAVEPOINT "%s"' % name)
 
 
@@ -1812,8 +1812,8 @@ def disable_invalid_filters(env):
         from openerp.tools.safe_eval import safe_eval
     import time
     try:
-        basestring
-    except:  # For Python 3 compatibility
+        basestring  # noqa: F821
+    except NameError:  # For Python 3 compatibility
         basestring = str
 
     def format_message(f):

--- a/openupgradelib/openupgrade_120.py
+++ b/openupgradelib/openupgrade_120.py
@@ -1,0 +1,397 @@
+# Copyright 2019 Tecnativa - Jairo Llopis
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+"""Tools specific for migrating Odoo 11.0 to 12.0.
+
+Important changes come from the update from Bootstrap 3 to 4.
+To understand these changes, these sources have been consulted, among others
+specific to some rules that can be consulted in inline comments:
+
+* http://upgrade-bootstrap.bootply.com/
+* https://bit.ly/2xmUHmo
+* https://getbootstrap.com/docs/4.3/migration/#stable-changes
+* https://github.com/odoo/odoo/wiki/Tips-and-tricks:-BS3-to-BS4
+
+Don't expect perfection. But patches are welcome.
+"""
+
+from itertools import product
+from psycopg2.extensions import AsIs
+
+from .openupgrade_tools import (
+    convert_html_fragment,
+    convert_html_replacement_class_shortcut as _r,
+)
+
+
+_COLS = range(1, 13)
+_CONTEXTS = (
+    # (BS3 context, BS4 context)
+    ("default", "secondary"),
+    ("primary", "primary"),
+    ("active", "active"),
+    ("disabled", "disabled"),
+    ("success", "success"),
+    ("info", "info"),
+    ("warning", "warning"),
+    ("danger", "danger"),
+)
+_TIERS = (
+    # (BS3 tier, BS4 tier)
+    ("-lg", "-xl"),
+    ("-md", "-lg"),
+    ("-sm", "-md"),
+    ("-xs", ""),
+)
+_BS3_VISIBLES = ("block", "inline", "inline-block")
+
+# These replacements are from standard Bootstrap 3 to 4
+_BS4_REPLACEMENTS = (
+    # Convert columns and modifiers among tiers
+    *(_r("col%s-%s" % (t3, col), "col%s-%s" % (t4, col))
+      for (t3, t4), col in product(_TIERS, _COLS)),
+    *(_r("col%s-offset-%s" % (t3, col), "offset%s-%s" % (t4, col))
+      for (t3, t4), col in product(_TIERS, _COLS)),
+    *(_r("col%s-pull-%s" % (t3, col), "order-first")
+      for (t3, t4), col in product(_TIERS, _COLS)),
+    *(_r("col%s-push-%s" % (t3, col), "order-last")
+      for (t3, t4), col in product(_TIERS, _COLS)),
+
+    # Typography
+    _r(selector="blockquote", class_add="blockquote"),
+    _r(selector="blockquote > small", class_add="blockquote-footer"),
+    _r("blockquote-reverse", "blockquote text-right"),
+    _r(selector=".list-inline > li", class_add="list-linline-item"),
+
+    # .page-header dropped. See https://stackoverflow.com/a/49708022/1468388
+    _r("page-header", "pb-2 mt-4 mb-2 border-bottom"),
+
+    # <dl> & co. See https://stackoverflow.com/a/56020841/1468388
+    _r("dl-horizontal", "row"),
+    _r(selector=".dl-horizontal > dt",
+       class_add="col-sm-3 text-sm-right"),
+    _r(selector=".dl-horizontal > dd", class_add="col-sm-9"),
+
+    # Images
+    _r("img-circle", "rounded-circle"),
+    _r("img-responsive", "img-fluid d-block"),
+    _r("img-rounded", "rounded"),
+
+    # Tables
+    _r("table-condensed", "table-sm"),
+    *(_r("%s" % c3, "table-%s" % c4, selector=".table .%s" % c3)
+      for (c3, c4) in _CONTEXTS),
+
+    # Forms
+    _r("control-label", "col-form-label"),
+    _r("form-group-lg", "form-control-lg"),
+    _r("form-group-sm", "form-control-sm"),
+    _r("input-lg", "form-control-lg"),
+    _r("input-sm", "form-control-sm"),
+    _r("help-block", "form-text"),
+    _r(selector="div.checkbox, div.radio",
+       class_rm="checkbox radio", class_add="form-check"),
+    _r(selector="div.form-check label", class_add="form-check-label"),
+    _r(selector="div.form-check input", class_add="form-check-input"),
+    _r(selector="label.checkbox-inline",
+       class_rm="checkbox-inline",
+       class_add="form-check-label form-check-inline"),
+    _r(selector=".checkbox-inline input",
+       class_rm="radio checkbox", class_add="form-check-input"),
+    _r(selector=".form-horizontal .form-group", class_add="row"),
+    _r(selector=".form-horizontal .form-group .control-label",
+       class_rm="control-label", class_add="col-form-label text-right"),
+    _r(selector=".form-horizontal", class_rm="form-horizontal"),
+    _r("form-control-static", "form-control-plaintext"),
+
+    # Input groups
+    _r(selector=".form-control + .input-group-addon",
+       class_rm="input-group-addon", class_add="input-group-text",
+       wrap="<span class='input-group-append'/>"),
+    _r(selector=".form-control + .input-group-btn",
+       class_rm="input-group-btn", class_add="input-group-append"),
+    _r("input-group-addon", "input-group-text",
+       wrap="<span class='input-group-prepend'/>"),
+    _r("input-group-btn", "input-group-prepend"),
+
+    # Buttons
+    _r("btn-default", "btn-secondary"),
+    _r("btn-xs", "btn-sm"),
+    _r("btn-group-xs", "btn-group-sm"),
+    _r("btn-group-justified", "w-100",
+       wrap='<div class="btn-group d-flex" role="group"/>'),
+    _r(selector=".btn-group + .btn-group", class_add="ml-1"),
+
+    # Dropdowns
+    _r("divider", "dropdown-divider", selector=".dropdown-menu > .divider"),
+    _r(selector=".dropdown-menu > li > a", class_add="dropdown-item"),
+
+    # List groups
+    _r("list-group-item", "list-group-item-action",
+       selector="a.list-group-item"),
+
+    # Navs
+    _r(selector=".nav > li", class_add="nav-item"),
+    _r(selector=".nav > li > a", class_add="nav-link"),
+    _r("nav-stacked", "flex-column"),
+
+    # Navbar
+    _r(selector="navbar", class_add="navbar-expand-sm"),
+    _r("navbar-default", "navbar-light"),
+    _r("navbar-toggle", "navbar-toggler"),
+    _r("navbar-form", "form-inline"),
+    _r("navbar-fixed-top", "fixed-top"),
+    _r("navbar-btn", "nav-item"),
+    _r("navbar-right", "ml-auto"),
+
+    # Pagination
+    _r(selector=".pagination > li", class_add="page-item"),
+    _r(selector=".pagination > li > a", class_add="page-link"),
+
+    # Breadcrumbs
+    _r(selector=".breadcrumb > li", class_add="breadcrumb-item"),
+
+    # Labels and badges
+    _r("label", "badge"),
+    _r("badge-default", "badge-secondary"),
+    *(_r("label-%s" % c3, "badge-%s" % c4) for (c3, c4) in _CONTEXTS),
+
+    # Convert panels, thumbnails and wells to cards
+    _r("panel", "card"),
+    _r("panel-body", "card-body"),
+    _r("panel-default"),
+    _r("panel-group"),
+    _r("panel-footer", "card-footer"),
+    _r("panel-heading", "card-header"),
+    _r("panel-title", "card-title"),
+    *(_r("panel-%s" % c3, "bg-%s" % c4) for (c3, c4) in _CONTEXTS),
+    _r("well", "card card-body"),
+    _r("thumbnail", "card card-body"),
+
+    # Progress
+    *(_r("progress-bar-%s" % c3, "bg-%s" % c4) for (c3, c4) in _CONTEXTS),
+    _r("active", "progress-bar-animated", selector=".progress-bar.active"),
+
+    # Carousel
+    _r("carousel-control left", "carousel-control-prev"),
+    _r("carousel-control right", "carousel-control-next"),
+    _r(selector=".item>.img", class_add="d-block"),
+    _r("item", "carousel-item", selector=".carousel .item"),
+    _r("left", "carousel-item-left", selector=".carousel .left"),
+    _r("next", "carousel-item-next", selector=".carousel .next"),
+    _r("prev", "carousel-item-prev", selector=".carousel .prev"),
+    _r("right", "carousel-item-right", selector=".carousel .right"),
+
+    # Utilities
+    _r("center-block", "d-block mx-auto"),
+    _r("hidden", "d-none"),
+    _r("hidden-xs", "d-none d-md-block"),
+    _r(selector=".hidden-sm",
+       class_rm="hidden-sm d-md-block",
+       class_add="d-md-none d-lg-block"),
+    _r(selector=".hidden-md",
+       class_rm="hidden-md d-lg-block",
+       class_add="d-lg-none d-xl-block"),
+    _r(selector=".hidden-lg",
+       class_rm="hidden-lg d-xl-block",
+       class_add="d-xl-none"),
+    _r("hidden-lg", "d-xl-none"),
+    *(_r("hidden%s" % t3, "d-none%s" % t4) for (t3, t4) in _TIERS),
+    _r("hidden-print", "d-print-none"),
+    *(_r("visible%s-%s" % (t3, vis), "d-")
+      for (t3, t4), vis in product(_TIERS, _BS3_VISIBLES)),
+    *(_r("visible-print-%s" % vis, "d-print-%s" % vis)
+      for vis in _BS3_VISIBLES),
+    _r("pull-left", "float-left"),
+    _r("pull-right", "float-right"),
+)
+
+# These replacements are specific for Odoo v11 to v12
+_ODOO12_REPLACEMENTS = (
+    # Grays renamed; handpicked closest gray equivalent matches
+    *(_r("bg-gray%s" % v11, "bg-%d00" % v12)
+      for v11, v12 in (
+          ("-darker", 9), ("-dark", 8), ("", 7),
+          ("-light", 6), ("-lighter", 1))),
+
+    # Odoo v12 editor adds/removes <b> tags, not <strong> tags; keep UX
+    _r(selector="strong", tag="b"),
+
+    # 25% opacity black background had white text in v11, but black in v12
+    _r(selector=".bg-black-25", class_add="text-white"),
+
+    # Image floating snippet disappears
+    _r(selector=".o_image_floating.o_margin_s.float-left", class_add="ml8"),
+    _r(selector=".o_image_floating.o_margin_s.float-right", class_add="mr8"),
+    _r(selector=".o_image_floating.o_margin_m.float-left",
+       style_add={"margin-left": "12px"}),
+    _r(selector=".o_image_floating.o_margin_m.float-right",
+       style_add={"margin-right": "12px"}),
+    _r(selector=".o_image_floating.o_margin_l.float-left", class_add="ml16"),
+    _r(selector=".o_image_floating.o_margin_l.float-right", class_add="mr16"),
+    _r(selector=".o_image_floating.o_margin_xl.float-left", class_add="ml32"),
+    _r(selector=".o_image_floating.o_margin_xl.float-right", class_add="mr32"),
+    _r(selector=".o_image_floating.o_margin_s", class_add="mb4"),
+    _r(selector=".o_image_floating.o_margin_m", class_add="mb8"),
+    _r(selector=".o_image_floating.o_margin_l",
+       style_add={"margin-bottom": "12px"}),
+    _r(selector=".o_image_floating.o_margin_xl", class_add="mb24"),
+    _r(selector=".o_image_floating .o_footer", class_rm="o_footer"),
+    _r("s_image_floating", "col-5"),
+    _r("o_image_floating o_margin_s o_margin_m o_margin_l o_margin_xl",
+       "col-5", selector=".o_image_floating"),
+
+    # Big message (v11) or Banner (v12) snippet
+    _r(selector=".jumbotron h1, .jumbotron .h1",
+       style_add={"font-size": "63px"}),
+    _r(selector=".jumbotron p", class_add="lead"),
+
+    # Big picture snippet
+    _r(selector=".s_big_picture h2", class_add="mt24"),
+
+    # Slider snippet
+    _r(selector=".s_banner",
+       style_rm={"height"}, style_add={"min-height": "400px"}),
+
+    # Text snippet loses its built-in headers
+    _r(selector=".s_text_block h2", class_add="mt24"),
+
+    # Cover snippet
+    _r(selector=".s_text_block_image_fw .container > .row > div",
+       style_add={"padding": "30px"}),
+
+    # Image gallery snippet
+    _r(selector=".s_image_gallery .o_indicators_left",
+       class_rm="fa fa-chevron-left",
+       class_add="text-center pt-2",
+       style_rm={"overflow", "padding", "border"}),
+    _r(selector=".s_image_gallery .o_indicators_left > br",
+       wrap='<i class="fa fa-chevron-left"/>'),
+    _r(selector=".s_image_gallery .o_indicators_right",
+       class_rm="fa fa-chevron-right",
+       class_add="text-center pt-2",
+       style_rm={"overflow", "padding", "border"}),
+    _r(selector=".s_image_gallery .o_indicators_right > br",
+       class_add="fa fa-chevron-right", tag="i"),
+
+    # Comparisons snippet
+    _r(selector=".s_comparisons > .container > .row > div",
+       class_add="s_col_no_bgcolor",
+       attr_add={"data-name": "Box"}),
+    _r(selector=".s_comparisons .card .list-group",
+       class_add="list-group-flush"),
+
+    # Company team snippet
+    _r(selector=".s_company_team h1", class_add="mt24"),
+
+    # Call to action snippet
+    _r(selector=".s_button .lead:first-child", class_rm="lead", tag="h3"),
+
+    # Parallax sliders
+    _r(selector=".s_parallax", style_add={"min-height": "200px"}),
+    _r(selector=".s_parallax_slider .blockquote",
+       style_add={"border-left": "5px solid #eeeeee"}),
+
+    # Accordion snippet
+    _r(selector=".s_faq_collapse .card-header h4", class_add="mb0"),
+    _r(selector=".s_faq_collapse .panel", class_add="mt6"),
+
+    # Well snippet
+    _r(selector=".s_well.card", class_add="bg-100"),
+
+    # Panel snippet
+    _r("s_panel", "s_card"),
+    _r(selector=".s_card.bg-secondary",
+       class_rm="bg-secondary", class_add="bg-white"),
+)
+
+ALL_REPLACEMENTS = _BS4_REPLACEMENTS + _ODOO12_REPLACEMENTS
+
+
+def convert_string_bootstrap_3to4(html_string, pretty_print=True):
+    """Convert an HTML string from Bootstrap 3 to 4.
+
+    :param str html_string:
+        Raw HTML fragment to convert.
+
+    :param bool pretty_print:
+        Indicate if you wish to return the HTML pretty formatted.
+
+    :return str:
+        Raw HTML fragment converted.
+    """
+    return convert_html_fragment(html_string, ALL_REPLACEMENTS, pretty_print)
+
+
+def convert_field_bootstrap_3to4(env, model_name, field_name, domain=None,
+                                 method='orm'):
+    """This converts all the values for the given model and field, being
+    able to restrict to a domain of affected records.
+    :param env: Odoo environment.
+    :param model_name: Name of the model that contains the field.
+    :param field_name: Name of the field that contains the BS3 HTML content.
+    :param domain: Optional domain for filtering records in the model
+    :param method: 'orm' (default) for using ORM; 'sql' for avoiding problems
+        with extra triggers in ORM.
+    """
+    assert method in {"orm", "sql"}
+    if method == "orm":
+        return _convert_field_bootstrap_3to4_orm(
+            env, model_name, field_name, domain,
+        )
+    records = env[model_name].search(domain or [])
+    return _convert_field_bootstrap_3to4_sql(
+        env.cr,
+        records._table,
+        field_name,
+    )
+
+
+def _convert_field_bootstrap_3to4_orm(env, model_name, field_name,
+                                      domain=None):
+    """Convert a field from Bootstrap 3 to 4, using Odoo ORM.
+
+    :param odoo.api.Environment env: Environment to use.
+    :param str model_name: Model to update.
+    :param str field_name: Field to convert in that model.
+    :param domain list: Domain to restrict conversion.
+    """
+    domain = domain or [(field_name, "!=", False)]
+    records = env[model_name].search(domain)
+    for rec in records:
+        old = rec[field_name]
+        if not old:
+            continue
+        new = convert_string_bootstrap_3to4(old)
+        if old != new:
+            rec[field_name] = new
+
+
+def _convert_field_bootstrap_3to4_sql(cr, table, field, ids=None):
+    """Convert a field from Bootstrap 3 to 4, using raw SQL queries.
+
+    :param odoo.sql_db.Cursor cr:
+        Database cursor.
+
+    :param str table:
+        Table name.
+
+    :param str field:
+        Field name, which should contain HTML content.
+
+    :param list ids:
+        List of IDs, to restrict operation to them.
+    """
+    sql = "SELECT id, %s FROM %s " % (field, table)
+    params = ()
+    if ids:
+        sql += "WHERE id IN %s"
+        params = (ids,)
+    cr.execute(sql, params)
+    for id_, old_content in cr.fetchall():
+        new_content = convert_string_bootstrap_3to4(old_content)
+        if old_content != new_content:
+            cr.execute(
+                "UPDATE %s SET %s = %s WHERE id = %s",
+                AsIs(table), AsIs(field), new_content, id_,
+            )

--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -323,59 +323,59 @@ def _adjust_merged_values_orm(env, model_name, record_ids, target_record_id,
         if not field.store or field.compute or field.related:
             continue  # don't do anything on these cases
         op = field_spec.get(field.name, False)
-        l = all_records.mapped(field.name)
+        _list = all_records.mapped(field.name)
         if field.type in ('char', 'text', 'html'):
             if not op:
                 op = 'other' if field.type == 'char' else 'merge'
             if op == 'merge':
-                l = filter(lambda x: x is not False, l)
-                vals[field.name] = ' | '.join(l)
+                _list = filter(lambda x: x is not False, _list)
+                vals[field.name] = ' | '.join(_list)
         elif field.type in ('integer', 'float', 'monetary'):
             if not op:
                 op = 'other' if field.type == 'integer' else 'sum'
             if op == 'sum':
-                vals[field.name] = sum(l)
+                vals[field.name] = sum(_list)
             elif op == 'avg':
-                vals[field.name] = sum(l) / len(l)
+                vals[field.name] = sum(_list) / len(_list)
             elif op == 'max':
-                vals[field.name] = max(l)
+                vals[field.name] = max(_list)
             elif op == 'min':
-                vals[field.name] = min(l)
+                vals[field.name] = min(_list)
         elif field.type == 'boolean':
             op = op or 'other'
             if op == 'and':
-                vals[field.name] = functools.reduce(lambda x, y: x & y, l)
+                vals[field.name] = functools.reduce(lambda x, y: x & y, _list)
             elif op == 'or':
-                vals[field.name] = functools.reduce(lambda x, y: x | y, l)
+                vals[field.name] = functools.reduce(lambda x, y: x | y, _list)
         elif field.type in ('date', 'datetime'):
             if op:
-                l = filter(lambda x: x is not False, l)
+                _list = filter(lambda x: x is not False, _list)
             op = op or 'other'
             if op == 'max':
-                vals[field.name] = max(l)
+                vals[field.name] = max(_list)
             elif op == 'min':
-                vals[field.name] = min(l)
+                vals[field.name] = min(_list)
         elif field.type == 'many2many':
             op = op or 'merge'
             if op == 'merge':
-                l = filter(lambda x: x is not False, l)
-                vals[field.name] = [(4, x.id) for x in l]
+                _list = filter(lambda x: x is not False, _list)
+                vals[field.name] = [(4, x.id) for x in _list]
         elif field.type == 'one2many':
             op = op or 'merge'
             if op == 'merge':
                 o2m_changes += 1
-                l.write({field.inverse_name: target_record_id})
+                _list.write({field.inverse_name: target_record_id})
         elif field.type == 'binary':
             op = op or 'merge'
             if op == 'merge':
-                l = [x for x in l if x]
-                if not getattr(target_record, field.name) and l:
-                    vals[field.name] = l[0]
+                _list = [x for x in _list if x]
+                if not getattr(target_record, field.name) and _list:
+                    vals[field.name] = _list[0]
         elif field.type == 'many2one':
             op = op or 'merge'
             if op == 'merge':
-                if not getattr(target_record, field.name) and l:
-                    vals[field.name] = l[0]
+                if not getattr(target_record, field.name) and _list:
+                    vals[field.name] = _list[0]
     # Curate values that haven't changed
     new_vals = {}
     for f in vals:

--- a/openupgradelib/openupgrade_tools.py
+++ b/openupgradelib/openupgrade_tools.py
@@ -21,6 +21,10 @@
 
 # A collection of functions split off from openupgrade.py
 # with no or only minimal dependencies
+import logging
+
+from lxml.etree import tostring
+from lxml.html import fromstring
 
 
 def table_exists(cr, table):
@@ -38,3 +42,164 @@ def column_exists(cr, table, column):
         'AND attname = %s',
         (table, column))
     return cr.fetchone()[0] == 1
+
+
+def convert_html_fragment(html_string, replacements, pretty_print=True):
+    """Get a string that contains XML and apply replacements to it.
+
+    :param str xml_string:
+        XML string object.
+
+    :param iterable[*dict] replacements:
+        The spec is any iterable full of dicts with this format:
+
+        .. code-block:: python
+
+            {
+                # This key is required, to find matching nodes
+                "selector": ".carousel .item",
+
+                # This is the default. Use ``xpath`` to select with XPath
+                "selector_mode": "css",
+
+                # Other keys are kwargs for ``convert_xml_node()``.
+                "class_rm": "item",
+                "class_add": "carousel-item",
+            },
+
+    :param bool pretty_print:
+        Indicates if the returned XML string should be indented.
+
+    :return str:
+        Converted XML string.
+    """
+    try:
+        fragment = fromstring(html_string)
+    except Exception:
+        logging.error("Failure converting string to DOM:\n%s", html_string)
+        raise
+    for spec in replacements:
+        instructions = spec.copy()
+        # Find matching nodes
+        selector = instructions.pop("selector")
+        mode = instructions.pop("selector_mode", "css")
+        assert mode in {"css", "xpath"}
+        finder = fragment.cssselect if mode == "css" else fragment.xpath
+        nodes = finder(selector)
+        # Apply node conversions as instructed
+        for node in nodes:
+            convert_xml_node(node, **instructions)
+    # Return new XML string
+    return tostring(fragment, pretty_print=pretty_print, encoding="unicode")
+
+
+def convert_xml_node(node,
+                     attr_add=None,
+                     attr_rm=frozenset(),
+                     class_add="",
+                     class_rm="",
+                     style_add=None,
+                     style_rm=frozenset(),
+                     tag="",
+                     wrap=""):
+    """Apply conversions to an XML node.
+
+    :param lxml.etree.Element node:
+        Node to be modified.
+
+    :param dict attr_add:
+        Attributes to add.
+
+    :param set attr_rm:
+        Attributes to remove.
+
+    :param str class_add:
+        Space-separated list of classes to add (for HTML nodes).
+
+    :param str class_rm:
+        Space-separated list of classes to remove (for HTML nodes).
+
+    :param dict style_add:
+        CSS styles to be added inline to the node (for HTML nodes). I.e.,
+        if you pass ``{"display": "none"}``,
+        a ``<div style="background-color:gray/>`` node would become
+        ``<div style="background-color:gray;display:none/>``.
+
+    :param set style_rm:
+        CSS styles to remove from the node (for HTML nodes). I.e.,
+        if you pass ``{"display"}``,
+        a ``<div style="background-color:gray;display:none/>`` node
+        would become ``<div style="background-color:gray/>``.
+
+    :param str tag:
+        Use it to alter the element tag.
+
+    :param str wrap:
+        XML element that will wrap the :param:`node`.
+    """
+    # Fix params
+    attr_add = attr_add or {}
+    class_add = set(class_add.split())
+    class_rm = set(class_rm.split())
+    style_add = style_add or {}
+    # Patch node attributes
+    if attr_add or attr_rm:
+        for key in attr_rm:
+            node.attrib.pop(key, None)
+        node.attrib.update(attr_add)
+    # Patch node classes
+    if class_add or class_rm:
+        classes = set(node.attrib.get("class", "").split())
+        classes = (classes | class_add) ^ class_rm
+        classes = " ".join(classes)
+        if classes:
+            node.attrib["class"] = classes
+        else:
+            node.attrib.pop("class", None)
+    # Patch node styles
+    if style_add or style_rm:
+        styles = node.attrib.get("style", "").split(";")
+        styles = {key.strip(): val.strip() for key, val in
+                  (style.split(":", 1) for style in styles if ":" in style)}
+        for key in style_rm:
+            styles.pop(key, None)
+        styles.update(style_add)
+        styles = ";".join(map(":".join, styles.items()))
+        if styles:
+            node.attrib["style"] = styles
+        else:
+            node.attrib.pop("style", None)
+    # Change its tag if needed
+    if tag:
+        node.tag = tag
+    # Wrap it if needed; see https://stackoverflow.com/a/56037842/1468388
+    if wrap:
+        wrapper = fromstring(wrap)
+        node.getparent().replace(node, wrapper)
+        wrapper.append(node)
+
+
+def convert_html_replacement_class_shortcut(class_rm="", class_add="",
+                                            **kwargs):
+    """Shortcut to create a class replacement spec.
+
+    :param str class_rm:
+        Space-separated string with classes to remove. If a selector kwarg
+        is not provided, these will be transformed to a selector, effectively
+        generating a class replacement result. For example, if this parameter
+        is ``"label badge"``, the default selector will be ``".label.badge"``.
+
+    :param str class_add:
+        Space-separated string with classes to add.
+
+    :return dict:
+        Generated spec, to be included in a list of replacements to be
+        passed to :meth:`convert_xml_fragment`.
+    """
+    kwargs.setdefault("selector", ".%s" % ".".join(class_rm.split()))
+    assert kwargs["selector"] != "."
+    kwargs.update({
+        "class_rm": class_rm,
+        "class_add": class_add,
+    })
+    return kwargs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 wheel
 coveralls
-# Version locked due to https://gitlab.com/pycqa/flake8/issues/268
-flake8==3.2.0
+flake8
 pep8-naming
 lxml
 psycopg2==2.7.3.1

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     packages=['openupgradelib'],
     package_dir={'openupgradelib': 'openupgradelib'},
     include_package_data=True,
-    install_requires=[],
+    install_requires=["lxml", "cssselect"],
     license=openupgradelib.__license__,
     zip_safe=False,
     keywords='openupgradelib',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,2 @@
 # -*- coding: utf-8 -*-
-import os
-from . import test_openupgradelib  # flake8: noqa
+from . import test_openupgradelib  # noqa: F401

--- a/tests/test_openupgradelib.py
+++ b/tests/test_openupgradelib.py
@@ -27,7 +27,7 @@ def import_mock(name, *args):
 
 
 if sys.version_info[0] == 3:
-    import builtins  # flake8: noqa
+    import builtins  # noqa: F401
     import_str = 'builtins.__import__'
 else:
     import_str = '__builtin__.__import__'
@@ -66,6 +66,7 @@ class TestOpenupgradelib(unittest.TestCase):
 
     def tearDown(self):
         pass
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In `openupgrade_tools`, I added some methods to perform transformation of XML strings based on given specs. The specs support some HTML-specific features, such as classes and styles. I provide also a handy shortcut for spec declaration.

I also added `openupgrade_120` with the spec for the Bootstrap 3 to 4 migration and a simple method that leverages the framework and spec to convert an XML string.

@Tecnativa