### PR TITLE
[IMP] rename_models: add mail_message_subtype in rename_models

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -635,6 +635,12 @@ def rename_models(cr, model_spec):
                 cr,
                 'UPDATE mail_message SET model=%s where model=%s', (new, old),
             )
+            if table_exists(cr, 'mail_message_subtype'):
+                logged_query(
+                    cr,
+                    'UPDATE mail_message_subtype SET res_model=%s '
+                    'where res_model=%s', (new, old),
+                )
             if table_exists(cr, 'mail_template'):
                 logged_query(
                     cr,


### PR DESCRIPTION
We left the model mail.message.subtype :S