### PR TITLE
[IMP] Improvements to website migration

### DIFF
--- a/openupgradelib/openupgrade_120.py
+++ b/openupgradelib/openupgrade_120.py
@@ -255,7 +255,9 @@ _ODOO12_REPLACEMENTS = (
 
     # Slider snippet
     _r(selector=".s_banner",
-       style_rm={"height"}, style_add={"min-height": "400px"}),
+       style_rm={"height"},
+       style_add=lambda styles, **kw: {
+           "min-height": styles.get("height", "400px")}),
 
     # Text snippet loses its built-in headers
     _r(selector=".s_text_block h2", class_add="mt24"),

--- a/openupgradelib/openupgrade_120.py
+++ b/openupgradelib/openupgrade_120.py
@@ -253,11 +253,21 @@ _ODOO12_REPLACEMENTS = (
     # Big picture snippet
     _r(selector=".s_big_picture h2", class_add="mt24"),
 
-    # Slider snippet
-    _r(selector=".s_banner",
+    # Slider (v11) or Carousel (v12) snippet
+    _r(selector=".carousel",
+       class_rm="s_banner oe_custom_bg",
+       class_add="s_carousel s_carousel_default",
        style_rm={"height"},
        style_add=lambda styles, **kw: {
            "min-height": styles.get("height", "400px")}),
+    _r(selector=".carousel-control-prev .fa-chevron-left",
+       class_rm="fa fa-chevron-left",
+       class_add="carousel-control-prev-icon",
+       tag="span"),
+    _r(selector=".carousel-control-next .fa-chevron-right",
+       class_rm="fa fa-chevron-right",
+       class_add="carousel-control-next-icon",
+       tag="span"),
 
     # Text snippet loses its built-in headers
     _r(selector=".s_text_block h2", class_add="mt24"),

--- a/openupgradelib/openupgrade_tools.py
+++ b/openupgradelib/openupgrade_tools.py
@@ -110,6 +110,9 @@ def convert_xml_node(node,
     :param dict attr_add:
         Attributes to add.
 
+        If the attribute is present, it won't be overwritten unless you add
+        it also to :param:`attr_rm`.
+
     :param set attr_rm:
         Attributes to remove.
 
@@ -124,6 +127,9 @@ def convert_xml_node(node,
         if you pass ``{"display": "none"}``,
         a ``<div style="background-color:gray/>`` node would become
         ``<div style="background-color:gray;display:none/>``.
+
+        If the style is present, it won't be overwritten unless you add
+        it also to :param:`style_rm`.
 
     :param set style_rm:
         CSS styles to remove from the node (for HTML nodes). I.e.,
@@ -146,7 +152,8 @@ def convert_xml_node(node,
     if attr_add or attr_rm:
         for key in attr_rm:
             node.attrib.pop(key, None)
-        node.attrib.update(attr_add)
+        for key, value in attr_add.items():
+            node.attrib.setdefault(key, value)
     # Patch node classes
     if class_add or class_rm:
         classes = set(node.attrib.get("class", "").split())
@@ -163,7 +170,8 @@ def convert_xml_node(node,
                   (style.split(":", 1) for style in styles if ":" in style)}
         for key in style_rm:
             styles.pop(key, None)
-        styles.update(style_add)
+        for key, value in style_add.items():
+            styles.setdefault(key, value)
         styles = ";".join(map(":".join, styles.items()))
         if styles:
             node.attrib["style"] = styles


### PR DESCRIPTION
Without this patch, if an XML node had a `style="height:333px"` and the rules set it to `style="height:222px"`, there was no way to avoid that.

Now, if you *really* want to replace a style or attribute, then just add it to the list of styles/attributes to remove. Otherwise, it will only be added if it was missing before.

@Tecnativa