### PR TITLE
[FIX] convert_xml_node: node.attrib doesn't have copy() method

### DIFF
--- a/openupgradelib/openupgrade_tools.py
+++ b/openupgradelib/openupgrade_tools.py
@@ -167,7 +167,7 @@ def convert_xml_node(node,
               (style.split(":", 1) for style in styles if ":" in style)}
     # Convert incoming callable arguments into values
     originals = {
-        "attrs": node.attrib.copy(),
+        "attrs": dict(node.attrib.items()),
         "classes": classes.copy(),
         "styles": styles.copy(),
         "tag": node.tag,


### PR DESCRIPTION
Trying to fix the "AttributeError: 'lxml.etree._Attrib' object has no attribute 'copy'".