### PR TITLE
[IMP] update_module_names: rename instead of merge case

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1002,7 +1002,10 @@ def update_module_names(cr, namespec, merge_modules=False):
         of just a renaming.
     """
     for (old_name, new_name) in namespec:
-        if merge_modules:
+        query = "SELECT id FROM ir_module_module WHERE name = %s"
+        cr.execute(query, [new_name])
+        row = cr.fetchone()
+        if row and merge_modules:
             # Delete meta entries, that will avoid the entry removal
             # They will be recreated by the new module anyhow.
             query = "SELECT id FROM ir_module_module WHERE name = %s"


### PR DESCRIPTION
Do a rename instead of merge if new_name doesn't exist yet. It may happens that you do a merge from an installed module to an uninstalled module, but the later is a new module (and thus is not yet in the ir.module.module list) and it is not installed.

Example:

In v11, you have customer_activity_statement and customer_outstanding_statement.
In v12, you have partner_statement, that both previous modules merge into.