### PR TITLE
[FIX] Remove call to `setdefault()`

### DIFF
--- a/openupgradelib/openupgrade_tools.py
+++ b/openupgradelib/openupgrade_tools.py
@@ -186,7 +186,8 @@ def convert_xml_node(node,
         for key in attr_rm:
             node.attrib.pop(key, None)
         for key, value in attr_add.items():
-            node.attrib.setdefault(key, value)
+            if key not in node.attrib:
+                node.attrib[key] = value
     # Patch node classes
     if class_add or class_rm:
         classes = (classes | class_add) ^ class_rm


### PR DESCRIPTION
`.attrib` is a dict-like proxy to the XML node attributes, but it lacks a `setdefault()` method.

Now this does the same, but without calling that method.

@Tecnativa