### PR TITLE
[IMP] Renaming index instead of dropping it while renaming columns

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -513,7 +513,10 @@ def rename_columns(cr, column_spec):
                         table, old, new)
             cr.execute(
                 'ALTER TABLE "%s" RENAME "%s" TO "%s"' % (table, old, new,))
-            cr.execute('DROP INDEX IF EXISTS "%s_%s_index"' % (table, old))
+            cr.execute(
+                'ALTER INDEX IF EXISTS "%s_%s_index" RENAME TO "%s_%s_index"' %
+                (table, old, table, new)
+            )
 
 
 def rename_fields(env, field_spec, no_deep=False):


### PR DESCRIPTION
[IMP] For small tables it's perfectly acceptable to drop index and then let Odoo recreate it, but with large tables this scenario is rather costly.