### PR TITLE
[IMP] delete_records_safely_by_xml_id: Avoid noisy log if the XML-ID is not found

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2225,7 +2225,9 @@ def delete_records_safely_by_xml_id(env, xml_ids):
         logger.debug('Deleting record for XML-ID %s', xml_id)
         try:
             with env.cr.savepoint():
-                env.ref(xml_id).exists().unlink()
+                record = env.ref(xml_id, raise_if_not_found=False)
+                if record and record.exists():
+                    record.unlink()
         except Exception as e:
             logger.error('Error deleting XML-ID %s: %s', xml_id, repr(e))
 


### PR DESCRIPTION
We should log if the record can't be removed (by constraints for example), but not if it's not found, as this is used in some places of the code for removing possible non existing records.