### PR TITLE
travis: Disable byte compiling when installing on Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ script:
     - pip install -q -r requirements.txt
     - export PYTHONPATH=~/build/OCA/openupgradelib:$PYTHONPATH
     - coverage run setup.py test
-    - python setup.py install
+    - python -B setup.py install
     # Run functional tests from 6.1 to 11.0
     - set -e
     - git clone https://github.com/oca/openupgrade --depth 1 --no-single-branch -b 6.1 ~/openupgrade


### PR DESCRIPTION
This should fix https://travis-ci.org/OCA/openupgradelib/builds/585505577