### PR TITLE
[FIX] Avoid deprecated openerp warning in >= 13.0

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -60,12 +60,12 @@ from . import openupgrade_tools
 
 core = None
 # The order matters here. We can import odoo in 9.0, but then we get odoo.py
-try:  # < 10.0
-    import openerp as core
-    from openerp.modules import registry
-except ImportError:  # >= 10.0
+try:  # >= 10.0
     import odoo as core
     from odoo.modules import registry
+except ImportError:  # < 10.0
+    import openerp as core
+    from openerp.modules import registry
 if hasattr(core, 'release'):
     release = core.release
 else:


### PR DESCRIPTION
Cause: https://github.com/odoo/odoo/commit/7c47eb185443af08a55b0045c6a78f74151dc083.