### PR TITLE
[FIX] Unify the way to convert query to unicode

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1121,9 +1121,9 @@ def logged_query(cr, query, args=None, skip_no_result=False):
     finally:
         if log_msg:
             try:
-                full_query = cr._obj.query.decode()
+                full_query = tools.ustr(cr._obj.query)
             except AttributeError:
-                full_query = cr.mogrify(query, args).decode()
+                full_query = tools.ustr(cr.mogrify(query, args))
             logger.log(
                 log_level, log_msg,
                 {"rowcount": cr.rowcount, "full_query": full_query},


### PR DESCRIPTION

Reuse the `ustr()` tool that Odoo provides, also making it more similar to how this is supported upstream in v11+ since https://github.com/odoo/odoo/pull/35834.

Fix #180.

@Tecnativa