### PR TITLE
[IMP] Faster workflow deletion

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -906,22 +906,49 @@ def update_workflow_workitems(cr, pool, ref_spec_actions):
             )
 
 
-def delete_model_workflow(cr, model):
+def delete_model_workflow(cr, model, drop_indexes=False):
     """
     Forcefully remove active workflows for obsolete models,
     to prevent foreign key issues when the orm deletes the model.
+
+    :param cr:
+        DB cursor.
+
+    :param str model:
+        Model name.
+
+    :param bool drop_indexes:
+        Do I drop indexes after finishing? If ``False``, those will be dropped
+        by a subsequent update of the ``workflow`` module in normal Odoo
+        probably.
     """
     # Save hours by adding needed indexes for affected FK constraints
-    index_name = sql.Identifier(get_legacy_name(
-        "wkf_triggers_workitem_id_index",
-    ))
-    logged_query(
-        cr,
-        sql.SQL("""
-            CREATE INDEX IF NOT EXISTS {} ON wkf_triggers
-            USING BTREE(workitem_id)
-        """).format(index_name)
-    )
+    to_index = {
+        "wkf_activity": ["subflow_id"],
+        "wkf_instance": ["wkf_id"],
+        "wkf_triggers": ["instance_id", "workitem_id"],
+        "wkf_workitem": ["act_id"],
+    }
+
+    def _index_loop():
+        for table, fields in to_index.items():
+            for col in fields:
+                index = sql.Identifier(
+                    "{tbl}_{col}_index".format(tbl=table, col=col),
+                )
+                table = sql.Identifier(table)
+                col = sql.Identifier(col)
+                yield index, table, col
+
+    for index, table, col in _index_loop():
+        logged_query(
+            cr,
+            sql.SQL("""
+                CREATE INDEX IF NOT EXISTS {} ON {}
+                USING BTREE({})
+            """).format(index, table, col)
+        )
+    # Delete workflows
     logged_query(
         cr,
         "DELETE FROM wkf_workitem WHERE act_id in "
@@ -933,8 +960,10 @@ def delete_model_workflow(cr, model):
     logged_query(
         cr,
         "DELETE FROM wkf WHERE osv = %s", (model,))
-    # Remove temporary index
-    logged_query(cr, sql.SQL("DROP INDEX {}").format(index_name))
+    # Remove temporary indexes if asked to do so
+    if drop_indexes:
+        for index, table, col in _index_loop():
+            logged_query(cr, sql.SQL("DROP INDEX {}").format(index))
 
 
 def warn_possible_dataloss(cr, pool, old_module, fields):


### PR DESCRIPTION

Following #184, here I'm adding more indexes to speed up workflow deletion even more. Let's save even more hours.

This time, I'm also adding `drop_indexes=False` argument. The created index names matches those created/deleted by Odoo addon update. This way, if you leave indexes there, subsequent calls will be even faster, and a simple addon update will let Odoo find and remove them.

@Tecnativa TT18838 https://github.com/OCA/OpenUpgrade/pull/2068