### PR TITLE
[FIX] delete_model_workflow: Do not reassign variables

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -932,13 +932,13 @@ def delete_model_workflow(cr, model, drop_indexes=False):
     }
 
     def _index_loop():
-        for table, fields in to_index.items():
-            for col in fields:
+        for table_name, fields in to_index.items():
+            for col_name in fields:
                 index = sql.Identifier(
-                    "{tbl}_{col}_index".format(tbl=table, col=col),
+                    "{}_{}_index".format(table_name, col_name),
                 )
-                table = sql.Identifier(table)
-                col = sql.Identifier(col)
+                table = sql.Identifier(table_name)
+                col = sql.Identifier(col_name)
                 yield index, table, col
 
     for index, table, col in _index_loop():


### PR DESCRIPTION

It seems like reassigning variables here changes the contents of the `to_index` dict, resulting in weird errors. Regression introduced in #189.

Fixed by changing variable names to avoid reusing them.

<details><summary>Failure logs</summary>

```
2019-10-31 14:33:16,150 1 ERROR prod OpenUpgrade: procurement: error in migration script procurement/migrations/8.0.1.0/pre-migration.py: TypeError('SQL identifiers must be strings',)
2019-10-31 14:33:16,150 1 ERROR prod OpenUpgrade: SQL identifiers must be strings
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 1691, in wrapped_function
    if use_env2 else cr, version)
  File "/opt/odoo/auto/addons/procurement/migrations/8.0.1.0/pre-migration.py", line 53, in migrate
    openupgrade.delete_model_workflow(cr, 'procurement.order')
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 944, in delete_model_workflow
    for index, table, col in _index_loop():
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 940, in _index_loop
    table = sql.Identifier(table)
  File "/usr/local/lib/python2.7/dist-packages/psycopg2/sql.py", line 311, in __init__
    raise TypeError("SQL identifiers must be strings")
TypeError: SQL identifiers must be strings
2019-10-31 14:33:16,152 1 CRITICAL prod openerp.service.server: Failed to initialize database `prod`.
Traceback (most recent call last):
  File "/opt/odoo/custom/src/odoo/openerp/service/server.py", line 941, in preload_registries
    registry = RegistryManager.new(dbname, update_module=update_module)
  File "/opt/odoo/custom/src/odoo/openerp/modules/registry.py", line 370, in new
    openerp.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 420, in load_modules
    force, status, report, loaded_modules, update_module, upg_registry)
  File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 312, in load_marked_modules
    loaded, processed = load_module_graph(cr, graph, progressdict, report=report, skip_modules=loaded_modules, perform_checks=perform_checks, upg_registry=upg_registry)
  File "/opt/odoo/custom/src/odoo/openerp/modules/loading.py", line 156, in load_module_graph
    migrations.migrate_module(package, 'pre')
  File "/opt/odoo/custom/src/odoo/openerp/modules/migration.py", line 179, in migrate_module
    mod.migrate(self.cr, pkg.installed_version)
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 1691, in wrapped_function
    if use_env2 else cr, version)
  File "/opt/odoo/auto/addons/procurement/migrations/8.0.1.0/pre-migration.py", line 53, in migrate
    openupgrade.delete_model_workflow(cr, 'procurement.order')
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 944, in delete_model_workflow
    for index, table, col in _index_loop():
  File "/usr/local/lib/python2.7/dist-packages/openupgradelib/openupgrade.py", line 940, in _index_loop
    table = sql.Identifier(table)
  File "/usr/local/lib/python2.7/dist-packages/psycopg2/sql.py", line 311, in __init__
    raise TypeError("SQL identifiers must be strings")
TypeError: SQL identifiers must be strings
```

</details>

@Tecnativa TT18838