### PR TITLE
[FIX] Invalidate filter if context is not a dict

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2091,6 +2091,7 @@ def disable_invalid_filters(env):
         # CONTEXT GROUP BY
         try:
             context = safe_eval(f.context, {'time': time, 'uid': env.uid})
+            assert(isinstance(context, dict))
         except Exception:
             logger.warning(
                 format_message(f) + "as it contains an invalid context %s.",


### PR DESCRIPTION
In case your users put the domain there instead of the context.
Prevents the migration breaking at the very end with
```
  File "/home/ou9/parts/odoo/odoo/addons/base/migrations/10.0.1.3/end-migration.py", line 31, in migrate
    openupgrade.disable_invalid_filters(env)
  File "/home/ou10/openupgradelib/openupgradelib/openupgrade.py", line 2103, in disable_invalid_filters
    if not context.get(key):
AttributeError: 'list' object has no attribute 'get'
```