### PR TITLE
[FIX] rename references in ir.filters when renaming models

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -797,6 +797,11 @@ def rename_models(cr, model_spec):
             "WHERE name LIKE %s",
             (new, old + ',%'),
         )
+        logged_query(
+            cr,
+            "UPDATE ir_filters SET model_id = %s "
+            "WHERE model_id = %s", (new, old,),
+        )
         # Handle properties that reference to this model
         logged_query(
             cr,


### PR DESCRIPTION
Rename references in user-defined filters (ir.filters) when renaming model.