### PR TITLE
[FIX] rename_fields: Don't rename only by name + reverse order

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -618,10 +618,15 @@ def rename_fields(env, field_spec, no_deep=False):
         # Rename appearances on export profiles
         # TODO: Rename when the field is part of a submodel (ex. m2one.field)
         cr.execute("""
-            UPDATE ir_exports_line
+            UPDATE ir_exports_line iel
             SET name = %s
-            WHERE name = %s
-            """, (old_field, new_field),
+            FROM ir_exports ie,
+                ir_model im
+            WHERE iel.name = %s
+                AND ie.id = iel.export_id
+                AND im.id = ie.model_id
+                AND im.model = %s
+            """, (new_field, old_field, model),
         )
         # Rename appearances on filters
         # Example of replaced domain: [['field', '=', self], ...]

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -611,8 +611,8 @@ def rename_fields(env, field_spec, no_deep=False):
             WHERE name = %s
                 AND type = 'model'
             """, (
-                "%s,%s" % (model, old_field),
                 "%s,%s" % (model, new_field),
+                "%s,%s" % (model, old_field),
             ),
         )
         # Rename appearances on export profiles


### PR DESCRIPTION
Doing that, you can rename exports from other models that match the field name.

I don't know how can this be so many time there without being aware of the problem...

TT24303