### PR TITLE
[FIX] rename_fields: Rename attachments for binary field

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -615,6 +615,14 @@ def rename_fields(env, field_spec, no_deep=False):
                 "%s,%s" % (model, old_field),
             ),
         )
+        # Rename possible attachments (if field is Binary with attachment=True)
+        cr.execute("""
+            UPDATE ir_attachment
+            SET res_field = %s
+            WHERE res_model = %s
+                AND res_field = %s
+            """, (new_field, model, old_field)
+        )
         # Rename appearances on export profiles
         # TODO: Rename when the field is part of a submodel (ex. m2one.field)
         cr.execute("""


### PR DESCRIPTION
If the field is Binary with attachment=True, the attachments are not renamed, and the content was lost.

Here we apply it unconditionally for every rename, as if the field is not binary or without attachments, the result of this will be 0 rows changed.

@Tecnativa TT23524