### PR TITLE
[FIX] Test invalid filters using a cursor savepoint

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2187,12 +2187,13 @@ def disable_invalid_filters(env):
         )
         # DOMAIN
         try:
-            # Strange artifact found in a filter
-            domain = f.domain.replace('%%', '%')
-            model.search(
-                safe_eval(domain, {'time': time, 'uid': env.uid}),
-                limit=1,
-            )
+            with savepoint(env.cr):
+                # Strange artifact found in a filter
+                domain = f.domain.replace('%%', '%')
+                model.search(
+                    safe_eval(domain, {'time': time, 'uid': env.uid}),
+                    limit=1,
+                )
         except Exception:
             logger.warning(
                 format_message(f) + "as it contains an invalid domain."


### PR DESCRIPTION
Fixes 
```
odoo.sql_db: bad query: SELECT "purchase_report".id FROM "purchase_report" WHERE ("purchase_report"."state" != 'cancel') ORDER BY "purchase_report"."date_order" DESC,"purchase_report"."price_total" DESC  limit 1
OpenUpgrade: FILTER DISABLED: Global Filter 'Monthly Purchases' for model 'purchase.report' has been disabled as it contains an invalid domain.
odoo.sql_db: bad query: UPDATE "ir_filters" SET "active"=false,"write_uid"=1,"write_date"=(now() at time zone 'UTC') WHERE id IN (10)
OpenUpgrade: base: error in migration script base/migrations/10.0.1.3/end-migration.py: InFailedSqlTransaction('current transaction is aborted, commands ignored until end of transaction block\n',)
OpenUpgrade: current transaction is aborted, commands ignored until end of transaction block
```
