### PR TITLE
Replace IN for ANY

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2687,7 +2687,7 @@ def cow_templates_mark_if_equal_to_upstream(cr, mark_colname=None):
     # Mark equal views
     logged_query(
         cr,
-        sql.SQL("UPDATE ir_ui_view SET {} = TRUE WHERE ID IN %s")
+        sql.SQL("UPDATE ir_ui_view SET {} = TRUE WHERE id = ANY(%s)")
         .format(mark_identifier),
         (equal,),
     )


### PR DESCRIPTION
Fixes https://github.com/OCA/OpenUpgrade/pull/2299/checks?check_run_id=1741234705#step:12:7045 from https://github.com/OCA/OpenUpgrade/pull/2299.

You cannot use `IN` to search in an `ARRAY`, which is the type of data that psycopg2 passes to postgres from a python `list`. Also, an empty `tuple` would fail too. Using `= ANY (%s)` is the safest.

@Tecnativa TT23136