### PR TITLE
[RVT] rename fields: revert deletion of existing ir_model_fields

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -597,7 +597,7 @@ def rename_fields(env, field_spec, no_deep=False):
         # Delete possible existing field entry
         # Example: https://github.com/OCA/OpenUpgrade/issues/2339
         cr.execute(
-            """DELETE FROM ir_model_fields WHERE name = %s AND model = %s""",
+            """DELETE ir_model_fields WHERE name = %s AND model = %s""",
             (new_field, model),
         )
         # Rename corresponding field entry
@@ -610,7 +610,7 @@ def rename_fields(env, field_spec, no_deep=False):
         )
         # Delete possible translations entries for new field
         cr.execute(
-            """DELETE FROM ir_translation WHERE name=%s AND type='model'""",
+            """DELETE ir_translation WHERE name=%s AND type='model'""",
             ("%s,%s" % (model, new_field), ),
         )
         # Rename translations

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -590,10 +590,6 @@ def rename_fields(env, field_spec, no_deep=False):
     cr = env.cr
     for model, table, old_field, new_field in field_spec:
         if column_exists(cr, table, old_field):
-            if column_exists(cr, table, new_field):
-                # Remnant of old versions? We rename existing one
-                # Example: https://github.com/OCA/OpenUpgrade/issues/2339
-                rename_columns(cr, {table: [(new_field, None)]})
             rename_columns(cr, {table: [(old_field, new_field)]})
         # Rename corresponding field entry
         cr.execute("""

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -592,14 +592,9 @@ def rename_fields(env, field_spec, no_deep=False):
         if column_exists(cr, table, old_field):
             if column_exists(cr, table, new_field):
                 # Remnant of old versions? We rename existing one
+                # Example: https://github.com/OCA/OpenUpgrade/issues/2339
                 rename_columns(cr, {table: [(new_field, None)]})
             rename_columns(cr, {table: [(old_field, new_field)]})
-        # Delete possible existing field entry
-        # Example: https://github.com/OCA/OpenUpgrade/issues/2339
-        cr.execute(
-            """DELETE ir_model_fields WHERE name = %s AND model = %s""",
-            (new_field, model),
-        )
         # Rename corresponding field entry
         cr.execute("""
             UPDATE ir_model_fields
@@ -607,11 +602,6 @@ def rename_fields(env, field_spec, no_deep=False):
             WHERE name = %s
                 AND model = %s
             """, (new_field, old_field, model),
-        )
-        # Delete possible translations entries for new field
-        cr.execute(
-            """DELETE ir_translation WHERE name=%s AND type='model'""",
-            ("%s,%s" % (model, new_field), ),
         )
         # Rename translations
         cr.execute("""


### PR DESCRIPTION
The deletion of ir_model_fields is harmful as it drops ir.property by cascade. This is currently what happens with product settings in OpenUpgrade 9.0. I'm working on an actual fix, but it would be good to prevent this unnoticed destruction of data in the mean time.
