### PR TITLE
[FIX] delete_records_safely_by_xml_id: env.ref can raise KeyError

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2546,10 +2546,11 @@ def delete_records_safely_by_xml_id(env, xml_ids):
     """
     for xml_id in xml_ids:
         logger.debug('Deleting record for XML-ID %s', xml_id)
-        record = env.ref(xml_id, raise_if_not_found=False)
-        if not record:
-            continue
         try:
+            # This can raise an environment KeyError if the model is not loaded
+            record = env.ref(xml_id, raise_if_not_found=False)
+            if not record:
+                continue
             safe_unlink(record, do_raise=True)
         except Exception as e:
             logger.info('Error deleting XML-ID %s: %s', xml_id, repr(e))


### PR DESCRIPTION
Regression of https://github.com/OCA/openupgradelib/pull/235
as can be seen here: https://github.com/OCA/OpenUpgrade/pull/2481/checks?check_run_id=2390489486#step:12:4180

```
  File "/home/runner/work/OpenUpgrade/OpenUpgrade/addons/survey/migrations/13.0.3.0/post-migration.py", line 82, in migrate
    openupgrade.delete_records_safely_by_xml_id(env, _unlink_by_xmlid)
  File "/opt/hostedtoolcache/Python/3.7.10/x64/lib/python3.7/site-packages/openupgradelib/openupgrade.py", line 2549, in delete_records_safely_by_xml_id
    record = env.ref(xml_id, raise_if_not_found=False)
  File "/home/runner/work/OpenUpgrade/OpenUpgrade/odoo/api.py", line 501, in ref
    return self['ir.model.data'].xmlid_to_object(xml_id, raise_if_not_found=raise_if_not_found)
  File "/home/runner/work/OpenUpgrade/OpenUpgrade/odoo/addons/base/models/ir_model.py", line 1725, in xmlid_to_object
    record = self.env[res_model].browse(res_id)
  File "/home/runner/work/OpenUpgrade/OpenUpgrade/odoo/api.py", line 463, in __getitem__
    return self.registry[model_name]._browse(self, (), ())
  File "/home/runner/work/OpenUpgrade/OpenUpgrade/odoo/modules/registry.py", line 180, in __getitem__
    return self.models[model_name]
KeyError: 'survey.stage'
```
