### PR TITLE
[IMP] delete_records_safely_by_xml_id: restrict Exception

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2561,7 +2561,8 @@ def delete_records_safely_by_xml_id(env, xml_ids):
             if not record:
                 continue
             safe_unlink(record, do_raise=True)
-        except Exception as e:
+        except (KeyError, IntegrityError,
+                core.exceptions.ValidationError) as e:
             logger.info('Error deleting XML-ID %s: %s', xml_id, repr(e))
             module, name = xml_id.split('.')
             imd = env["ir.model.data"].search(


### PR DESCRIPTION
This way, we can detect cases where the method is called wrong, for example passing the cr instead of the env.