### PR TITLE
[IMP] update_module_names: set noupdate = FALSE in remaining occurrences

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1403,7 +1403,7 @@ def update_module_names(cr, namespec, merge_modules=False):
         # to auto-remove related resources
         query = ("UPDATE ir_model_data "
                  "SET name = name || '_openupgrade_' || id, "
-                 "module = %s "
+                 "module = %s, noupdate = FALSE "
                  "WHERE module = %s")
         logged_query(cr, query, (new_name, old_name))
         query = ("UPDATE ir_module_module_dependency SET name = %s "


### PR DESCRIPTION
There are models, like `ir.rule`, where its records usually are `noupdate = True`, and they may affect the databases if they are left in the database.

For example, this issue happens in stock (v11) because there are two `ir.rule`, one in 'procurement' module and the other in 'stock' module, that both have the same xmlid name (product_pulled_flow_comp_rule), and in v11, procurement is merged in stock.