### PR TITLE
[FIX] rename_models: also rename models in res_id of ir.property

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -825,6 +825,16 @@ def rename_models(cr, model_spec):
             "UPDATE ir_filters SET model_id = %s "
             "WHERE model_id = %s", (new, old,),
         )
+        logged_query(
+            cr, """
+            UPDATE ir_property
+            SET res_id = replace(res_id, %(old_string)s, %(new_string)s)
+            WHERE res_id like %(old_pattern)s""", {
+                "old_pattern": "%s,%%" % old,
+                "old_string": "%s," % old,
+                "new_string": "%s," % new,
+            },
+        )
         # Handle properties that reference to this model
         logged_query(
             cr,

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -841,14 +841,12 @@ def rename_models(cr, model_spec):
             logged_query(
                 cr, """
                 UPDATE ir_property
-                SET value_reference = regexp_replace(
-                    value_reference, %(old_pattern)s, %(new_pattern)s
-                )
-                WHERE fields_id IN %(field_ids)s
-                AND value_reference ~ %(old_pattern)s""", {
-                    'field_ids': tuple(field_ids),
-                    'old_pattern': r"^%s,[ ]*([0-9]*)" % old,
-                    'new_pattern': r"%s,\1" % new,
+                SET value_reference = replace(
+                    value_reference, %(old_string)s, %(new_string)s)
+                WHERE value_reference like %(old_pattern)s""", {
+                    "old_pattern": "%s,%%" % old,
+                    "old_string": "%s," % old,
+                    "new_string": "%s," % new,
                 },
             )
         # Update export profiles references


### PR DESCRIPTION
Until today it didn't matter (and still doesn't matter, but maybe in the future, who knows...) because the usual models in that column are product.template, product.category, res.partner, product.product, ...