### PR TITLE
[IMP] upgrade_path: support upgrade paths (separated by commas)

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -294,9 +294,13 @@ def load_data(cr, module_name, filename, idref=None, mode='init'):
         fp = tools.file_open(pathname)
     except OSError:
         if tools.config.get('upgrade_path'):
-            pathname = os.path.join(
-                tools.config['upgrade_path'], module_name, filename)
-            fp = open(pathname)
+            for path in tools.config['upgrade_path'].split(','):
+                pathname = os.path.join(path, module_name, filename)
+                try:
+                    fp = open(pathname)
+                    break
+                except OSError:
+                    pass
         else:
             raise
 


### PR DESCRIPTION
Odoo CE has support the list of upgrade paths, we should be support it to PATH_TO_openupgrade_scripts_MODULE of any repository does not need to contain source code
