### PR TITLE
Add pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
 import openupgradelib
 
 from setuptools import setup


### PR DESCRIPTION
Explicitly declare that setuptools is the build backend
for this project, so it can be installed in environment
where setuptools is not pre-installed.

closes #276