### PR TITLE
[FIX] disable_invalid_filters: datetime / context_today / relativedelta is not defined

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2372,6 +2372,18 @@ def disable_invalid_filters(env):
         globaldict = {'uid': env.uid}
         if version_info[0] < 14:
             globaldict.update({'time': time})
+        if version_info[0] >= 13:
+            try:
+                from odoo.tools.safe_eval import datetime as safe_eval_datetime
+                from odoo.tools.safe_eval import dateutil
+            except ImportError:
+                import datetime as safe_eval_datetime
+                import dateutil
+            globaldict.update({
+                'datetime': safe_eval_datetime,
+                'context_today': safe_eval_datetime.datetime.now,
+                'relativedelta': dateutil.relativedelta.relativedelta,
+            })
         # DOMAIN
         try:
             with savepoint(env.cr):


### PR DESCRIPTION
Ref: https://github.com/odoo/odoo/blob/15.0/odoo/addons/base/models/ir_filters.py#L39-L44