### PR TITLE
[FIX] bad openupgrade import in legacy code for openupgrade 7.0

### DIFF
--- a/openupgradelib/openupgrade_70.py
+++ b/openupgradelib/openupgrade_70.py
@@ -23,7 +23,7 @@
 # This module provides simple tools for openupgrade migration, specific for
 # the 6.1 -> 7.0 migration. It is kept in later editions to keep all the API
 # docs in the latest release.
-import openupgrade
+from . import openupgrade
 
 
 def set_partner_id_from_partner_address_id(


### PR DESCRIPTION
Use the same relative import as in the other openupgrade_xx files. 