### PR TITLE
[FIX] mail_activity_type rename in merge_models method

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1003,13 +1003,16 @@ def merge_models(cr, old_model, new_model, ref_field):
             ('mail_message', 'model', 'res_id', ''),
             ('mail_message_subtype', 'res_model', '', ''),
             ('mail_activity', 'res_model', 'res_id', 'res_model_id'),
-            ('mail_activity_type', '', '', 'res_model_id'),
             ('mail_template', 'model', '', 'model_id'),
             ('mail_alias', '', '', 'alias_model_id'),
             ('mail_alias', '', 'alias_parent_thread_id',
              'alias_parent_model_id'),
             # mail_followers: special case handled below
         ]
+        if version_info[0] < 15:
+            renames.append(('mail_activity_type', '', '', 'res_model_id'))
+        else:
+            renames.append(('mail_activity_type', 'res_model', '', ''))
     for (table, model_name_column, res_id_column, model_id_column) in renames:
         if not table_exists(cr, table):
             continue


### PR DESCRIPTION
Cc @Tecnativa TT41247

From Odoo version 15.0, in `mail.activity.type` model, the field that stores a reference to `res.model` is `res_model` and not `res_model_id` field as in previous versions, so we need to take this into account in the `merge_models` method when updating `mail.activity.type`.
    Odoo 14.0: https://github.com/odoo/odoo/blob/fe87755a4499f68de4625fd9940f25960896bc55/addons/mail/models/mail_activity.py#L58
    odoo 15.0: https://github.com/odoo/odoo/blob/5553ad50bf54bef986038f94e8c8462e2547a927/addons/mail/models/mail_activity_type.py#L46