### PR TITLE
[FIX] toctree: set 3 maxdepth to see all the methods signatures

### DIFF
--- a/docsource/index.rst
+++ b/docsource/index.rst
@@ -9,7 +9,7 @@ Welcome to OpenUpgrade Library's documentation!
 Contents:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    readme
    installation


### PR DESCRIPTION
Rational : 
- max depth was set to 2 in openupgradelib documentation : https://github.com/OCA/openupgradelib/blob/master/docsource/index.rst
- max depth is set to 3 in openupgrade documentation : https://github.com/OCA/OpenUpgrade/blob/documentation/docsource/index.rst

As a result, method signatures and explanation are not shown. ([ref](https://github.com/OCA/OpenUpgrade/pull/3863#issuecomment-1549799519))

This PR should fix the problem.