### PR TITLE
[DOC] turn CI into red, if there are warning in sphinx call

### DIFF
--- a/.github/workflows/documentation-commit.yml
+++ b/.github/workflows/documentation-commit.yml
@@ -12,53 +12,28 @@ on:
 jobs:
   documentation-commit:
     runs-on: ubuntu-22.04
+    container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
     steps:
-      - name: Check out OpenUpgrade Documentation
-        uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Check out Odoo
-        uses: actions/checkout@v2
-        with:
-          repository: odoo/odoo
-          ref: "16.0"
-          fetch-depth: 1
-          path: odoo
-      - name: Configuration
+      - uses: actions/checkout@v3
+
+      # See: https://github.com/OCA/openupgradelib/pull/324#issuecomment-1556255121
+      - name: configure Git
         run: |
-          sudo apt update
-          sudo apt install \
-              expect \
-              expect-dev \
-              libevent-dev \
-              libldap2-dev \
-              libsasl2-dev \
-              libxml2-dev \
-              libxslt1-dev \
-              nodejs \
-              python3-lxml \
-              python3-passlib \
-              python3-psycopg2 \
-              python3-serial \
-              python3-simplejson \
-              python3-werkzeug \
-              python3-yaml \
-              unixodbc-dev
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Requirements Installation
         run: |
-          pip install -r odoo/requirements.txt
           pip install -e .
           pip install -r ./doc_requirements.txt
+
       - name: OpenUpgradelib Docs
         run: |
           # try to build the documentation
           python3 -m sphinx -W -d ./docs/.doctrees ./docsource ./docs
 
       - name: Commit changes
-        uses: EndBug/add-and-commit@v7
+        uses: EndBug/add-and-commit@v9
         with:
           add: "docs"
           default_author: github_actions

--- a/.github/workflows/documentation-commit.yml
+++ b/.github/workflows/documentation-commit.yml
@@ -55,7 +55,7 @@ jobs:
       - name: OpenUpgradelib Docs
         run: |
           # try to build the documentation
-          python3 -m sphinx -d ./docs/.doctrees ./docsource ./docs
+          python3 -m sphinx -W -d ./docs/.doctrees ./docsource ./docs
 
       - name: Commit changes
         uses: EndBug/add-and-commit@v7

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -53,4 +53,4 @@ jobs:
       - name: OpenUpgradelib Docs
         run: |
           # try to build the documentation
-          python3 -m sphinx -d ./docs/.doctrees ./docsource ./docs
+          python3 -m sphinx -W -d ./docs/.doctrees ./docsource ./docs

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,45 +8,19 @@ on:
 
 jobs:
   documentation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    container: ghcr.io/oca/oca-ci/py3.10-odoo16.0:latest
     steps:
-      - name: Check out OpenUpgrade Documentation
-        uses: actions/checkout@v2
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Check out Odoo
-        uses: actions/checkout@v2
-        with:
-          repository: odoo/odoo
-          ref: "16.0"
-          fetch-depth: 1
-          path: odoo
-      - name: Configuration
+      - uses: actions/checkout@v3
+
+      # See: https://github.com/OCA/openupgradelib/pull/324#issuecomment-1556255121
+      - name: configure Git
         run: |
-          sudo apt update
-          sudo apt install \
-              expect \
-              expect-dev \
-              libevent-dev \
-              libldap2-dev \
-              libsasl2-dev \
-              libxml2-dev \
-              libxslt1-dev \
-              nodejs \
-              python3-lxml \
-              python3-passlib \
-              python3-psycopg2 \
-              python3-serial \
-              python3-simplejson \
-              python3-werkzeug \
-              python3-yaml \
-              unixodbc-dev
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Requirements Installation
         run: |
-          pip install -q -r odoo/requirements.txt
           pip install -e .
           pip install -r ./doc_requirements.txt
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -13,6 +13,7 @@ To contribute to the openupgradelib documentation:
 
     git clone https://github.com/odoo/odoo -b 16.0 --depth=1 ./src/odoo
     virtualenv env --python=python3.10
+    ./env/bin/pip install -r ./src/odoo/requirements.txt
     ./env/bin/pip install -e ./src/odoo/
     ./env/bin/pip install -e .
     ./env/bin/pip install -r ./doc_requirements.txt
@@ -24,5 +25,4 @@ To contribute to the openupgradelib documentation:
 
 .. code:: shell
 
-    . ./env/bin/activate
-    python3 -m sphinx -W -d ./docs/.doctrees ./docsource ./docs
+    ./env/bin/python -m sphinx -W -d ./docs/.doctrees ./docsource ./docs

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -25,4 +25,4 @@ To contribute to the openupgradelib documentation:
 .. code:: shell
 
     . ./env/bin/activate
-    python3 -m sphinx -d ./docs/.doctrees ./docsource ./docs
+    python3 -m sphinx -W -d ./docs/.doctrees ./docsource ./docs

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ OpenUpgrade Library
 A library with support functions to be called from Odoo migration scripts.
 
 * Free software: AGPL-3 license
-* Documentation: https://openupgradelib.readthedocs.org.
+* Documentation: https://oca.github.io/openupgradelib
 
 Install
 -------


### PR DESCRIPTION
For the time being, CI is green, if there are warning during the call of sphinx to build documentation.

https://github.com/OCA/openupgradelib/actions/runs/4993898715/jobs/8943675293#step:7:28