### PR TITLE
[FIX] delete_record_translation: invalid input syntax for type json

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2688,7 +2688,7 @@ def delete_record_translations(cr, module, xml_ids, field_list=None):
                 columns=", ".join(list_columns),
                 values=", ".join(
                     [
-                        '\'{{"en_US": {x} -> "en_US"}}\'::jsonb'.format(x=x)
+                        "jsonb_build_object('en_US', {x} -> 'en_US')".format(x=x)
                         for x in list_columns
                     ]
                 ),


### PR DESCRIPTION
I notice it going to error , check this PR `https://github.com/OCA/OpenUpgrade/pull/4040` 
Why not using `jsonb_build_object`