### PR TITLE
[FIX] `rating_rating` does not have `parent_res_model` column

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1079,7 +1079,7 @@ def rename_models(cr, model_spec):
                     "UPDATE mail_activity SET res_model=%s where res_model=%s",
                     (new, old),
                 )
-        if table_exists(cr, "rating_rating"):
+        if column_exists(cr, "rating_rating", "parent_res_model"):
             logged_query(
                 cr,
                 "UPDATE rating_rating SET parent_res_model=%s where parent_res_model=%s",


### PR DESCRIPTION
SEE [Issue](https://github.com/OCA/openupgradelib/issues/347)

@pedrobaeza I have added only the `column_exists` condition as it implicitly checks whether the table exists or not:
![Screenshot_299](https://github.com/OCA/openupgradelib/assets/4418005/319bfbe1-0049-451d-92c5-4d8207643d5d)
