### PR TITLE
[FIX] openupgrade_160: _convert_field_bootstrap_4to5_sql ids

### DIFF
--- a/openupgradelib/openupgrade_160.py
+++ b/openupgradelib/openupgrade_160.py
@@ -389,7 +389,7 @@ def _convert_field_bootstrap_4to5_sql(cr, table, field, ids=None):
     params = ()
     if ids:
         sql += "WHERE id IN %s"
-        params = (ids,)
+        params = (tuple(ids),)
     cr.execute(sql, params)
     for id_, old_content in cr.fetchall():
         new_content = convert_string_bootstrap_4to5(old_content)


### PR DESCRIPTION
related: https://github.com/OCA/OpenUpgrade/pull/4205#issuecomment-1790261528

```python
>>> ids = [1, 3, 5]
>>> (ids,)
([1, 3, 5],)
>>> (tuple(ids),)
((1, 3, 5),)
```

cc @Tecnativa TT45734

ping @pedrobaeza 