### PR TITLE
[FIX][IMP] _convert_field_bootstrap_4to5_orm: translatable fields

### DIFF
--- a/openupgradelib/openupgrade_tools.py
+++ b/openupgradelib/openupgrade_tools.py
@@ -400,7 +400,7 @@ def not_html_empty_where_clause(column):
     :return string:
         The where clause for the html column ready to select only values with content.
     """
-    return f"""
+    return """
     NOT (
         {column} IS NULL
         OR {column} = ''
@@ -412,4 +412,6 @@ def not_html_empty_where_clause(column):
                 'g'
             ) ~ '\\S'
         )
-    )"""
+    )""".format(
+        column=column
+    )


### PR DESCRIPTION
The improvement made in 40741d960477bfcfea5c1e6a518863a7e6f92065 couldn't deal with json columns of translatable fields.

In any case a more simpler approach can be took if we simply discard all the records which don't even have a `class` attribute in their html code, meaning that we don't need to make the Bootstrap migration at all.

cc @Tecnativa TT46020