### PR TITLE
[FIX] openupgrade_merge_records: Adjust m2o value with ORM

### DIFF
--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -485,7 +485,10 @@ def apply_operations_by_field_type(
             if method != "orm":
                 field_vals = [x for x in field_vals if x]
             if not first_value and field_vals:
-                vals[column] = field_vals[0]
+                if method == "orm":
+                    vals[column] = field_vals[0].id
+                else:
+                    vals[column] = field_vals[0]
     elif (
         field_type == "many2one_reference"
         and method == "orm"


### PR DESCRIPTION
The passed value is a recordset, so we should assign the ID of it.

Solves OCA/OpenUpgrade#4419

@Tecnativa 