### PR TITLE
[FIX] migrate_translations_to_jsonb: Less verbose

### DIFF
--- a/openupgradelib/openupgrade_160.py
+++ b/openupgradelib/openupgrade_160.py
@@ -79,7 +79,7 @@ def migrate_translations_to_jsonb(env, fields_spec):
                 env.cr, field
             )
             for query in migrate_queries:
-                logged_query(env.cr, query)
+                env.cr.execute(query)
     # Just leave it as it was if we renamed it
     if rename_translation_table:
         logged_query(env.cr, "ALTER TABLE _ir_translation RENAME TO ir_translation")


### PR DESCRIPTION
We can't log each translation query, as they are a lot (one per record of each of the translatable columns for all the models), and there are columns like ir_ui_view~arch_db that are very long.

@Tecnativa 