### PR TITLE
latest setuptool_scm version is not compatible with python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     include_package_data=True,
     setup_requires=[
         "setuptools_scm<6.0.0; python_version <= '3.6'",
-        "setuptools_scm; python_version > '3.6'",
+        "setuptools_scm<8; python_version < '3.8'",
+        "setuptools_scm; python_version >= '3.8'",
     ],
     install_requires=[
         "lxml",


### PR DESCRIPTION
Version 8.0.0 of setuptools_scm onwards imports Protocol from typing but Protocol is not available for versions of python3.7, which is the one used by the odoo:13.0 and odoo:14.0 docker

https://github.com/pypa/setuptools_scm/blob/b5dbba7a154b90f401ac1b9ca37dc920b5e82c33/src/setuptools_scm/_config.py#L11