### PR TITLE
[FIX] load_data: fail early on missing path

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -333,6 +333,11 @@ def load_data(env_or_cr, module_name, filename, idref=None, mode="init"):
                     break
                 except OSError:  # pylint: disable=W7938
                     pass
+            else:
+                raise OSError(
+                    "Couldn't find file %s in upgrade path (%s)"
+                    % (filename, tools.config["upgrade_path"])
+                )
         else:
             raise
 

--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -335,7 +335,7 @@ def load_data(env_or_cr, module_name, filename, idref=None, mode="init"):
                     pass
             else:
                 raise OSError(
-                    "Couldn't find file %s in upgrade path (%s)"
+                    "Couldn't find file %s in the upgrade paths (%s)"
                     % (filename, tools.config["upgrade_path"])
                 )
         else:


### PR DESCRIPTION
Without this patch, if you call this function with a filename that can't be found, you'll get a confusing error like `NameError: name 'fp' is not defined`, that gives no details about the real problem.

@moduon MT-7047