### PR TITLE
[FIX] m2o_to_x2m: fix dup key insertion

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1904,8 +1904,11 @@ def m2o_to_x2m(cr, model, table, field, source_field):
             SELECT id, %s
             FROM %s
             WHERE %s is not null
+            EXCEPT
+            SELECT %s, %s
+            FROM %s
             """
-            % (rel, id1, id2, source_field, table, source_field),
+            % (rel, id1, id2, source_field, table, source_field, id1, id2, rel),
         )
     elif isinstance(columns[field], tuple(o2m_types)):
         if isinstance(columns[field], One2many):  # >= 8.0


### PR DESCRIPTION
Hello, while trying to migrate a production database to v15, during the project_hr post-migration script (the one removed here https://github.com/OCA/project/commit/5e35249f097595e32454c33d112310c28078f397):

```
def migrate(env, version):
    # Convert m2o to m2m in 'project.task'
    openupgrade.m2o_to_x2m(
        env.cr,
        env["project.task"],
        "project_task",
        "employee_ids",
        "employee_id",
    )
```

I got this error:

```
2024-09-01 18:36:23,184 153 INFO tec14-updated odoo.modules.migration: module project_hr: Running migration [15.0.1.0.0>] post-migration
2024-09-01 18:36:23,192 153 INFO tec14-updated OpenUpgrade: project_hr: post-migration script called with version 14.0.1.0.0
2024-09-01 18:36:23,193 153 ERROR tec14-updated odoo.sql_db: bad query:
            INSERT INTO hr_employee_project_task_rel (project_task_id, hr_employee_id)
            SELECT id, employee_id
            FROM project_task
            WHERE employee_id is not null

ERROR: duplicate key value violates unique constraint "hr_employee_project_task_rel_pkey"
DETAIL:  Key (project_task_id, hr_employee_id)=(197, 64) already exists.

2024-09-01 18:36:23,194 153 ERROR tec14-updated OpenUpgrade: Error after 0:00:00.000908 running
            INSERT INTO hr_employee_project_task_rel (project_task_id, hr_employee_id)
            SELECT id, employee_id
            FROM project_task
            WHERE employee_id is not null

2024-09-01 18:36:23,194 153 ERROR tec14-updated OpenUpgrade: project_hr: error in migration script /odoo/external-src/project/project_hr/migrations/15.0.1.0.0/post-migration.py: duplicate key value violates
unique constraint "hr_employee_project_task_rel_pkey"
DETAIL:  Key (project_task_id, hr_employee_id)=(197, 64) already exists.
2024-09-01 18:36:23,194 153 ERROR tec14-updated OpenUpgrade: project_hr: error in migration script /odoo/external-src/project/project_hr/migrations/15.0.1.0.0/post-migration.py: duplicate key value violates
unique constraint "hr_employee_project_task_rel_pkey"
DETAIL:  Key (project_task_id, hr_employee_id)=(197, 64) already exists.

2024-09-01 18:36:23,194 153 ERROR tec14-updated OpenUpgrade: duplicate key value violates unique constraint "hr_employee_project_task_rel_pkey"
DETAIL:  Key (project_task_id, hr_employee_id)=(197, 64) already exists.

Traceback (most recent call last):
  File "/env/lib/python3.8/site-packages/openupgradelib/openupgrade.py", line 2292, in wrapped_function
    func(
  File "/odoo/external-src/project/project_hr/migrations/15.0.1.0.0/post-migration.py", line 10, in migrate
    openupgrade.m2o_to_x2m(
  File "/env/lib/python3.8/site-packages/openupgradelib/openupgrade.py", line 1900, in m2o_to_x2m
    logged_query(
  File "/env/lib/python3.8/site-packages/openupgradelib/openupgrade.py", line 1703, in logged_query
    cr.execute(query, args)
  File "/env/lib/python3.8/site-packages/decorator.py", line 232, in fun
    return caller(func, *(extras + args), **kw)
  File "/odoo/src/odoo/sql_db.py", line 90, in check
    return f(self, *args, **kwargs)
  File "/odoo/src/odoo/sql_db.py", line 311, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "hr_employee_project_task_rel_pkey"
DETAIL:  Key (project_task_id, hr_employee_id)=(197, 64) already exists.
```

I asked chatGPT how I could avoid inserting duplicates and it suggested me this fix with EXCEPT. With this fix I got my migration working and the relation table was populated:

```
tec14-updated=> select count(*) from hr_employee_project_task_rel;
 count
-------
  1856
(1 row)
```

cc @aleuffre @pilarvargas-tecnativa @pedrobaeza 