### PR TITLE
[UPD] m2o_to_x2m: docstring recommends outdated usage

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -1867,8 +1867,9 @@ def get_model2table(model):
 def m2o_to_x2m(cr, model, table, field, source_field):
     """
     Transform many2one relations into one2many or many2many.
-    Use rename_columns in your pre-migrate script to retain the column's old
-    value, then call m2o_to_x2m in your post-migrate script.
+    For openupgrade < 14.0, use rename_columns in your pre-migrate script
+    to retain the column's old value, then call m2o_to_x2m in your
+    post-migrate script.
 
     WARNING: If converting to one2many, there can be data loss, because only
     one inverse record can be mapped in a one2many, but you can have multiple


### PR DESCRIPTION
it's not true for some versions of OpenUpgrade already that we need to retain the column's value manually, because we centrally [patch away dropping columns](https://github.com/OCA/OpenUpgrade/blob/14.0/openupgrade_framework/odoo_patch/odoo/addons/base/models/ir_model.py#L34).

The recommendation leads to [confusion](https://github.com/OCA/OpenUpgrade/pull/4465#discussion_r1806480453), so I suggest to restrict it to ancient versions of OpenUpgrade.