### PR TITLE
[IMP]openupgrade: disable_invalid_filters

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2898,6 +2898,13 @@ def disable_invalid_filters(env, verbose=True):
                     )
                     f.active = False
                     break
+        # ACTION_ID
+        if f.action_id and not f.action_id.exists():
+            logger.warning(
+                format_message(f) + "as it contains an invalid action_id %s.",
+                f.action_id,
+            )
+            f.active = False
 
 
 def add_fields(env, field_spec):


### PR DESCRIPTION
### Trying to solve
After a migration it was not possible to open the settings submenu: "User-defined filters".
This was due to invalid user filters.

### Cause
The current script is not testing action_id. Some user filters contained deleted `ir.actions.actions`.
It was then failing when performing the `web_read`.

In this PR I'm adding a test related to the inhexistance of the related `ir.actions.actions`.
