### PR TITLE
[FIX] load_data: switch to binary mode for recent versions

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -329,7 +329,10 @@ def load_data(env_or_cr, module_name, filename, idref=None, mode="init"):
     pathname = os.path.join(module_name, filename)
 
     try:
-        fp = tools.file_open(pathname)
+        if version_info[0] >= 11:
+            fp = tools.file_open(pathname, "rb")
+        else:
+            fp = tools.file_open(pathname)
     except OSError:
         if tools.config.get("upgrade_path"):
             for path in tools.config["upgrade_path"].split(","):


### PR DESCRIPTION
We found the following error when trying to upload csv files via the load_data method:

```
Traceback (most recent call last):
  File "/home/odoo/src/openupgradelib/openupgradelib/openupgrade.py", line 2304, in wrapped_function
    func(
  File "/home/odoo/src/repositories/ingadhoc-odoo-saas-adhoc/saas_client_l10n_ar/migrations/16.0.1.9.0/post-migration.py", line 12, in migrate
    openupgrade.load_data(env.cr, 'l10n_ar', 'data/res.country.csv')
  File "/home/odoo/src/openupgradelib/openupgradelib/openupgrade.py", line 353, in load_data
    tools.convert_csv_import(
  File "/home/odoo/src/odoo/odoo/tools/convert.py", line 780, in convert_csv_import
    reader = pycompat.csv_reader(io.BytesIO(csvcontent), quotechar='"', delimiter=',')
TypeError: a bytes-like object is required, not 'str'
2024-12-13 17:27:20,327 75 WARNING test-bidargentinasa-13-12-2 odoo.modules.loading: Transient module states were reset 
2024-12-13 17:27:20,328 75 ERROR test-bidargentinasa-13-12-2 odoo.modules.registry: Failed to load registry 
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/modules/registry.py", line 91, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 484, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 372, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/home/odoo/src/odoo/odoo/modules/loading.py", line 236, in load_module_graph
    migrations.migrate_module(package, 'post')
  File "/home/odoo/src/odoo/odoo/modules/migration.py", line 189, in migrate_module
    migrate(self.cr, installed_version)
  File "/home/odoo/src/openupgradelib/openupgradelib/openupgrade.py", line 2304, in wrapped_function
    func(
  File "/home/odoo/src/repositories/ingadhoc-odoo-saas-adhoc/saas_client_l10n_ar/migrations/16.0.1.9.0/post-migration.py", line 12, in migrate
    openupgrade.load_data(env.cr, 'l10n_ar', 'data/res.country.csv')
  File "/home/odoo/src/openupgradelib/openupgradelib/openupgrade.py", line 353, in load_data
    tools.convert_csv_import(
  File "/home/odoo/src/odoo/odoo/tools/convert.py", line 780, in convert_csv_import
    reader = pycompat.csv_reader(io.BytesIO(csvcontent), quotechar='"', delimiter=',')
TypeError: a bytes-like object is required, not 'str'
2024-12-13 17:27:20,329 75 WARNING <databasename> odoo.addons.saas_client.cli.fixdb: Could not fix dbs, this is what we get a bytes-like object is required, not 'str' 
```
This is because it is expecting a binary file and it is receiving a str.
