### PR TITLE
[IMP] rename_models: add condition to check version and existence of ir_property table

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -977,19 +977,6 @@ def rename_models(cr, model_spec):
         )
         logged_query(
             cr,
-            """
-            UPDATE ir_property
-            SET res_id = replace(res_id, %(old_string)s, %(new_string)s)
-            WHERE res_id like %(old_pattern)s""",
-            {
-                "old_pattern": "%s,%%" % old,
-                "old_string": "%s," % old,
-                "new_string": "%s," % new,
-            },
-        )
-        # Handle properties that reference to this model
-        logged_query(
-            cr,
             "SELECT id FROM ir_model_fields "
             "WHERE relation = %s AND ttype = 'many2one'",
             (old,),
@@ -1003,20 +990,34 @@ def rename_models(cr, model_spec):
                 old,
             ),
         )
-        if field_ids:
+        if version_info[0] < 18:
             logged_query(
                 cr,
                 """
                 UPDATE ir_property
-                SET value_reference = replace(
-                    value_reference, %(old_string)s, %(new_string)s)
-                WHERE value_reference like %(old_pattern)s""",
+                SET res_id = replace(res_id, %(old_string)s, %(new_string)s)
+                WHERE res_id like %(old_pattern)s""",
                 {
                     "old_pattern": "%s,%%" % old,
                     "old_string": "%s," % old,
                     "new_string": "%s," % new,
                 },
             )
+            # Handle properties that reference to this model
+            if field_ids:
+                logged_query(
+                    cr,
+                    """
+                    UPDATE ir_property
+                    SET value_reference = replace(
+                        value_reference, %(old_string)s, %(new_string)s)
+                    WHERE value_reference like %(old_pattern)s""",
+                    {
+                        "old_pattern": "%s,%%" % old,
+                        "old_string": "%s," % old,
+                        "new_string": "%s," % new,
+                    },
+                )
         # Handle models that reference to this model using reference fields
         cr.execute(
             """


### PR DESCRIPTION
model `ir.property` was removed in commit https://github.com/odoo/odoo/commit/de302c2 in version `18.0` so if new databases is initialized from 18.0 onwards will not have `ir_property` table then there will be an error exception that `relation ir_property does not exist` when using the `rename_models` function