### PR TITLE
[FIX] Don't pin setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ flake8
 pep8-naming
 lxml<=4.3.4
 psycopg2==2.7.3.1
-setuptools<58.0
+setuptools


### PR DESCRIPTION
For avoiding this incompatibility:

```
ERROR: setuptools==57.5.0 is used in combination with setuptools-scm>=8.x
```

Linked with https://github.com/Tecnativa/doodba-copier-template/issues/520

Being honest, not sure why we need such libraries. I know this is for something related with the publishing to PyPi, but didn't dig into details.

@Tecnativa 