### PR TITLE
safe_unlink: No log error on unlink error

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3319,7 +3319,7 @@ def safe_unlink(records, do_raise=False):
         if not record.exists():
             continue
         try:
-            with record.env.cr.savepoint():
+            with record.env.cr.savepoint(), core.tools.mute_logger("odoo.sql_db"):
                 record.unlink()
         except Exception as e:
             if do_raise:


### PR DESCRIPTION
Avoid the error in the log that can be intepreted incorrectly when reading it. Tools that make use of this method (like delete_records_safely_by_xml_id) are already emitting the corresponding log.

Visually, this goes from (alarming OU users):

![imagen](https://github.com/user-attachments/assets/3c83cd7a-af58-49c0-ba96-45f95d7b145a)

to:

![imagen](https://github.com/user-attachments/assets/42806cd9-de1f-4a79-b26e-e451b85f1e4f)

@Tecnativa