### PR TITLE
[FIX] merge_records: norecompute was deprecated in v17

### DIFF
--- a/openupgradelib/openupgrade_merge_records.py
+++ b/openupgradelib/openupgrade_merge_records.py
@@ -1061,7 +1061,10 @@ def merge_records(
         _change_translations_orm(*args)
         args2 = args0 + (field_spec,) + (delete,)
         # TODO: serialized fields
-        with env.norecompute():
+        if 7 < version_info[0] < 17:
+            with env.norecompute():
+                _adjust_merged_values_orm(*args2)
+        else:
             _adjust_merged_values_orm(*args2)
         if version_info[0] > 15:
             env[model_name].flush_model()


### PR DESCRIPTION
See https://github.com/odoo-dev/odoo/commit/4b1c9a89529bea56d4837e0065070d8463f46258.