### PR TITLE
[FIX] add_columns: Don't consider False for non boolean columns

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3086,7 +3086,7 @@ def add_columns(env, field_spec):
                 sql.SQL(sql_type),
             )
             args = []
-            if init_value is not None:
+            if init_value or (init_value is not None and field_type == "boolean"):
                 query += sql.SQL(" DEFAULT %s")
                 args.append(init_value)
             logged_query(cr, query, args)


### PR DESCRIPTION
This way, we keep the compatibility with existing calls to add_fields using False as "filling value" in specifications of non boolean fields.

Fixes #416

@Tecnativa