### PR TITLE
[IMP] Fix SQL alias for JSON_OBJECT_AGG: use \"value\" to avoid synta…

### DIFF
--- a/openupgradelib/openupgrade_180.py
+++ b/openupgradelib/openupgrade_180.py
@@ -50,7 +50,7 @@ def convert_company_dependent(
         FROM (
             SELECT
             SPLIT_PART(res_id, ',', 2)::integer res_id,
-            JSON_OBJECT_AGG(company_id, {value_expression}) value
+            JSON_OBJECT_AGG(company_id, {value_expression}) AS "value"
             FROM ir_property
             WHERE
             fields_id={old_field_id or Field.id} AND res_id IS NOT NULL


### PR DESCRIPTION
When running OpenUpgrade 18.0 on PostgreSQL 13.0 , queries using `JSON_OBJECT_AGG(..., ...) value`
or `row_number(...) sequence` raise a syntax error due to unquoted alias names. 

This PR fixes:
- `value` → `"value"`


to ensure compatibility with PostgreSQL reserved keywords and avoid `syntax error at or near ...`.

This patch unblocks migration from Odoo 17.0 to 18.0 for affected modules (e.g. `res.partner`, `product_document`).
