### PR TITLE
[FIX] add_columns: remove default False for boolean field

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3090,7 +3090,7 @@ def add_columns(env, field_spec):
                 query += sql.SQL(" DEFAULT %s")
                 args.append(init_value)
             logged_query(cr, query, args)
-            if init_value:
+            if init_value or (init_value is not None and field_type == "boolean"):
                 logged_query(
                     cr,
                     sql.SQL("ALTER TABLE {} ALTER COLUMN {} DROP DEFAULT").format(


### PR DESCRIPTION
It seems it was forgotten in https://github.com/OCA/openupgradelib/pull/418.