### PR TITLE
[FIX] prevent build rollback on odoo.sh

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -2383,7 +2383,7 @@ def migrate(no_version=False, use_env=None, uid=None, context=None):
                     # Python3: fetch pyfile from locals, not fp
                     filename = frame.locals.get("pyfile") or frame.locals["fp"].name
                 except Exception as exc:
-                    logger.error(
+                    logger.warning(
                         "'migrate' decorator: failed to inspect the frame above: %s",
                         exc,
                     )


### PR DESCRIPTION
Odoo.sh consider builds as failed if an error is logged (regardless of the fact that we continue with the migration script or not). Following odoo PR #202014, this will happen more frequently in the `migrate` function as `pkg` is not available anymore