### PR TITLE
[IMP] load_data: support v19 upgrade_path

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -349,7 +349,11 @@ def load_data(env_or_cr, module_name, filename, idref=None, mode="init"):
             fp = tools.file_open(pathname)
     except OSError:
         if tools.config.get("upgrade_path"):
-            for path in tools.config["upgrade_path"].split(","):
+            if version_info[0] >= 19:
+                upgrade_paths = tools.config["upgrade_path"]
+            else:
+                upgrade_paths = tools.config["upgrade_path"].split(",")
+            for path in upgrade_paths:
                 pathname = os.path.join(path, module_name, filename)
                 try:
                     fp = open(pathname)


### PR DESCRIPTION
in v18 and before, upgrade_path was a comma separated [string](https://github.com/OCA/OCB/blob/18.0/odoo/tools/config.py#L123), while it's parsed as a [list](https://github.com/OCA/OCB/blob/19.0/odoo/tools/config.py#L243) in v19