### PR TITLE
[FIX] openupgrade: eager-import odoo submodules for Odoo 19 compatibility

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     from io import StringIO
 
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 
 try:
     from psycopg2 import IntegrityError, ProgrammingError, errorcodes
@@ -55,6 +55,28 @@ core = None
 # The order matters here. We can import odoo in 9.0, but then we get odoo.py
 try:  # >= 10.0
     import odoo as core
+
+    # Odoo 19 stopped eager-loading these submodules from `odoo/__init__.py`,
+    # so `import odoo as core` no longer makes `core.fields`, `core.api` etc.
+    # accessible as attributes. Earlier versions worked because Odoo's package
+    # init imported them itself. Eager-import them here so the module-level
+    # attribute lookups below (e.g. ``Many2many = core.fields.Many2many``)
+    # keep working on 19+. ImportError is suppressed individually so older
+    # Odoo versions with a slightly different layout still import cleanly;
+    # any submodule that genuinely matters will fail loudly when accessed
+    # below as ``core.<missing>``.
+    for _submod in (
+        "odoo.fields",
+        "odoo.tools",
+        "odoo.tools.mail",
+        "odoo.exceptions",
+        "odoo.api",
+        "odoo.osv",
+        "odoo.release",
+    ):
+        with suppress(ImportError):
+            __import__(_submod)
+    del _submod
     from odoo.modules import registry
 except ImportError:  # < 10.0
     import openerp as core


### PR DESCRIPTION
In Odoo <= 18, `odoo/__init__.py` eager-imported submodules like `fields`, `api`, `tools`, `exceptions`, etc., so `import odoo as core` was enough to access them as `core.fields.Many2many`, `core.api`, ...

In Odoo 19, `odoo/__init__.py` no longer does these eager imports. As a result, openupgradelib fails to import under Odoo 19 with:

    AttributeError: module 'odoo' has no attribute 'fields'
    AttributeError: module 'odoo' has no attribute 'api'

at module load time (lines that read `core.fields.Many2many` and `api = core.api`). This breaks the OCA/OpenUpgrade 19.0 migration path: `openupgrade_framework` is loaded as a server-wide module, which imports openupgradelib, which fails before any migration script can run.

Eager-import the submodules referenced at module level right after `import odoo as core`. Each import is wrapped in try/except so older Odoo versions with a slightly different module layout still work.

Verified end-to-end: Odoo 18.0.20250924 → 19.0.20260508 OpenUpgrade migration completes cleanly (`Modules loaded`, registry loaded in 414s, zero ERROR/CRITICAL) on a vanilla Community install with this patch.