### PR TITLE
[FIX] update_module_moved_fields: handle pre-existing new_module XML-IDs

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3425,6 +3425,35 @@ def update_module_moved_fields(cr, model, moved_fields, old_module, new_module):
         "fields": tuple(moved_fields),
     }
     # update xml-id entries
+    #
+    # First, drop any old_module XML-IDs that would collide with an already-
+    # existing new_module XML-ID for the same field. The unique constraint on
+    # ir_model_data is (module, name) — the previous `NOT IN (SELECT id ...)`
+    # filter compared on `id`, not on `name`, so when the new_module had
+    # already auto-registered XML-IDs for the moved fields (which is exactly
+    # the case after a major upgrade in which the field's owning module has
+    # changed in the source tree), the subsequent UPDATE crashed with a
+    # UniqueViolation. Deleting the redundant old_module rows first restores
+    # idempotency — the new_module already has the canonical XML-IDs.
+    logged_query(
+        cr,
+        """
+        DELETE FROM ir_model_data imd
+        USING ir_model_fields imf
+        WHERE
+            imf.model = %(model)s AND
+            imf.name IN %(fields)s AND
+            imd.module = %(old_module)s AND
+            imd.model = 'ir.model.fields' AND
+            imd.res_id = imf.id AND
+            EXISTS (
+                SELECT 1 FROM ir_model_data x
+                WHERE x.module = %(new_module)s
+                  AND x.name = imd.name
+            )
+        """,
+        vals,
+    )
     logged_query(
         cr,
         """
@@ -3436,10 +3465,7 @@ def update_module_moved_fields(cr, model, moved_fields, old_module, new_module):
             imf.name IN %(fields)s AND
             imd.module = %(old_module)s AND
             imd.model = 'ir.model.fields' AND
-            imd.res_id = imf.id AND
-            imd.id NOT IN (
-               SELECT id FROM ir_model_data WHERE module = %(new_module)s
-            )
+            imd.res_id = imf.id
         """,
         vals,
     )


### PR DESCRIPTION
## Problem

`update_module_moved_fields` UPDATEs `ir_model_data` rows from `old_module` to `new_module`, with `imd.id NOT IN (SELECT id FROM ir_model_data WHERE module = new_module)` to filter out conflicts. The filter compares on `id`, not on the unique-constraint columns `(module, name)`.

When the new_module has already auto-registered XML-IDs for the moved fields — which is the case after a major upgrade where a field has been moved from one module to another in the source tree — the UPDATE crashes with:

```
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "ir_model_data_module_name_uniq_index"
DETAIL: Key (module, name)=(<new_module>, <field_xmlid>) already exists.
```

## Reproduction

Run an OpenUpgrade migration from 17.0 to 18.0 on a database with `agreement_legal` (OCA/agreement repo) installed. In 18.0 OCA, the `agreement_ids` and `agreements_count` fields on `res.partner` moved from `agreement_legal` to `agreement`. `agreement/migrations/18.0.1.1.0/post-mig.py` calls:

```python
openupgrade.update_module_moved_fields(
    cr, "res.partner",
    ["agreement_ids", "agreements_count"],
    "agreement_legal", "agreement",
)
```

By that point `agreement` has already auto-registered its own XML-IDs at module-install time. The UPDATE then collides and the whole migration aborts.

First caught in production at PLANA Pulse during the 17→18 migration on 2026-05-22; worked around in our migration Job by SQL-pre-deleting the colliding rows, but the cleanest fix lives upstream.

## Fix

Pre-delete `old_module` rows that would collide with an existing `new_module` row for the same field (the canonical copies are already under `new_module`). Then UPDATE the rest as before. The combined effect is identical when there's no collision (the DELETE matches nothing) and idempotent when there is.

## Tested with

- Odoo 18.0 + OCA/agreement on a 17.0 → 18.0 OpenUpgrade migration (post-fix: clean exit).
- Same migration on a tenant DB without `agreement_legal` (DELETE matches 0 rows, UPDATE matches 0 rows — no-op, no regression).