### PR TITLE
[FIX] docs: add 14.0 + 18.0 method sections to API.rst

### DIFF
--- a/docsource/API.rst
+++ b/docsource/API.rst
@@ -71,6 +71,16 @@ release.
 .. automodule:: openupgradelib.openupgrade_130
    :members:
 
+Methods for OpenUpgrade 14.0
+----------------------------
+
+The following specific methods for 14.0 are available. These have been
+developed to cover specific needs as per data model changes in that
+release.
+
+.. automodule:: openupgradelib.openupgrade_140
+   :members:
+
 Methods for OpenUpgrade 16.0
 ----------------------------
 
@@ -79,4 +89,14 @@ developed to cover specific needs as per data model changes in that
 release.
 
 .. automodule:: openupgradelib.openupgrade_160
+   :members:
+
+Methods for OpenUpgrade 18.0
+----------------------------
+
+The following specific methods for 18.0 are available. These have been
+developed to cover specific needs as per data model changes in that
+release.
+
+.. automodule:: openupgradelib.openupgrade_180
    :members:

--- a/openupgradelib/openupgrade_140.py
+++ b/openupgradelib/openupgrade_140.py
@@ -72,6 +72,7 @@ def convert_field_html_string_13to14(
 ):
     """This converts all the values for the given model and field, being
     able to restrict to a domain of affected records.
+
     :param env: Odoo environment.
     :param model_name: Name of the model that contains the field.
     :param field_name: Name of the field that contains the HTML content.


### PR DESCRIPTION
## What
Add the missing **14.0** and **18.0** method sections to `docsource/API.rst`. Both modules (`openupgrade_140.py`, `openupgrade_180.py`) exist but were never wired into the API docs, so the published page stopped at 16.0.

## Also
Fixes an RST indentation warning in `convert_field_html_string_13to14`'s docstring (missing blank line before the `:param` list) that `sphinx -W` surfaces once the 14.0 module is documented.

Source-only — `docs/` is regenerated by `documentation-commit.yml` on push. Verified: `sphinx -W` builds clean; both `convert_html_string_13to14` and `convert_company_dependent` now render.

Supersedes #432.
