### PR TITLE
[IMP] check_valid_filters: Use search_count and add missing context fields

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3192,10 +3192,17 @@ def disable_invalid_filters(env, verbose=True):
             with savepoint(env.cr):
                 # Strange artifact found in a filter
                 domain = f.domain.replace("%%", "%")
-                model.search(
-                    safe_eval(domain, globaldict),
-                    limit=1,
-                )
+                if version_info[0] < 16:
+                    model.search(
+                        safe_eval(domain, globaldict),
+                        limit=1,
+                        count=True,
+                    )
+                else:
+                    model.search_count(
+                        safe_eval(domain, globaldict),
+                        limit=1,
+                    )
         except Exception as e:
             logger.warning(
                 format_message(f) + "as it contains an invalid domain %s. Detail: %s",
@@ -3216,7 +3223,13 @@ def disable_invalid_filters(env, verbose=True):
             )
             f.active = False
             continue
-        keys = ["group_by", "col_group_by"]
+        keys = [
+            "group_by",
+            "col_group_by",
+            "pivot_measures",
+            "pivot_row_groupby",
+            "pivot_column_groupby",
+        ]
         for key in keys:
             if not context.get(key):
                 continue


### PR DESCRIPTION
Some filters on non optimized models (sale.report.delivered) were taking a really long time to check because search is fetching all the fields, I think we can safely assume that if it doesn't crash with search_count it also won't crash once migrated.

Also, pivot views use different context keys that were not being checked.

@pedrobaeza @sergio-teruel 
TT62385 @tecnativa