### PR TITLE
[FIX] delete_record_translations: only consider jsonb columns

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3049,14 +3049,18 @@ def delete_record_translations(cr, module, xml_ids, field_list=None):
                 )
         else:
             table = get_model2table(model)
-            # we use information_schema to assure the columns exist
+            # we use information_schema to assure the columns exist and are
+            # jsonb; legacy non-jsonb columns (e.g. a leftover varchar column
+            # of a no-longer-stored field) would crash the operators below
             cr.execute(
                 """
                 SELECT isc.column_name
                 FROM information_schema.columns isc
                 JOIN ir_model_fields imf ON (
                     imf.name = isc.column_name AND imf.model = %s)
-                WHERE isc.table_name = %s AND imf.translate"""
+                WHERE isc.table_name = %s
+                    AND isc.data_type = 'jsonb'
+                    AND imf.translate"""
                 + (
                     # translate is a boolean in <19, a select field afterwards
                     ""


### PR DESCRIPTION
## Problem

`delete_record_translations()` selects the columns to clean by joining `information_schema.columns` (column physically exists) with `ir_model_fields` (field is flagged translatable), but never verifies the column is actually `jsonb` before running jsonb operators on it (`col ? 'en_US'`, `jsonb_object_keys(col)`).

Databases can carry legacy non-jsonb columns for fields that are flagged translatable. Typical case: an orphan varchar column of a field that is no longer stored — Odoo never drops columns when a field disappears or becomes non-stored. Real-world example: a physical varchar `product_product.name` column (the field is a non-stored related field in current versions).

On such a database, any migration script calling
`delete_record_translations()` on a record of the affected model crashes. Hit in practice during a 17.0 → 18.0 OpenUpgrade run, where the `hr_expense` `18.0.2.0` post-migration passes xml_ids that resolve to `product.product` records:

psycopg2.errors.UndefinedFunction:
operator does not exist: character varying ? unknown LINE 2: SELECT name IS NOT NULL AND (name ? 'en_US')...

The failure is data-dependent (only databases whose history produced such an orphan column are affected), which makes it confusing to diagnose — the same migration passes on sibling databases.

## Fix

Add `isc.data_type = 'jsonb'` to the column selection. A non-jsonb column cannot hold jsonb translations, so there is nothing to clean there and skipping it is always correct. No behavior change for well-formed schemas.