### PR TITLE
[IMP] cow_templates_replicate_upstream: also update inherit_id

### DIFF
--- a/openupgradelib/openupgrade.py
+++ b/openupgradelib/openupgrade.py
@@ -3929,8 +3929,20 @@ def cow_templates_replicate_upstream(cr, mark_colname=None):
         sql.SQL(
             """
             UPDATE ir_ui_view AS specific
-            SET arch_db = generic.arch_db
+            SET arch_db = generic.arch_db,
+                inherit_id = COALESCE(
+                    (
+                        SELECT sp.id FROM ir_ui_view AS sp
+                        WHERE sp.key = generic_parent.key
+                        AND sp.website_id = specific.website_id
+                        AND sp.type = 'qweb'
+                        LIMIT 1
+                    ),
+                    generic.inherit_id
+                )
             FROM ir_ui_view AS generic
+            LEFT JOIN ir_ui_view AS generic_parent
+                ON generic_parent.id = generic.inherit_id
             WHERE
                 specific.{} IS NOT NULL AND
                 specific.website_id IS NOT NULL AND


### PR DESCRIPTION
`cow_templates_replicate_upstream` only copies `arch_db` from the generic view to its COW'd copies, not `inherit_id`. 

That's enough when a module migration only changes the content of the parent template, but not when the migration itself re-targets which template the view inherits from — the COW copy keeps the old `inherit_id` and view combination still fails at render time, even after `arch_db` is refreshed.

This showed up in a real migration: OCA/e-commerce#1295 restructures `website_sale_product_attribute_filter_category`'s view because `website_sale` moved the attribute-filter loop to a different template between 18.0 and 19.0. A website that had the option toggled on in 18.0 kept crashing `/shop` after upgrading, because its COW copy still inherited from the old template.

The fix copies `inherit_id` along with `arch_db`, but first checks whether the new parent template itself has its own COW copy for that same website — if so, it points there instead of at the generic parent, preserving that website's own customization chain. When the parent didn't change, or there's no website-specific copy of it, it falls back to `generic.inherit_id` as before (no-op / same behavior as the initial version of this fix).

@Tecnativa TT64160
@pedrobaeza @pilarvargas-tecnativa 